### PR TITLE
Add support for simplified Options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ RELEASE_IMAGE ?= $(LOCAL_IMAGE)
 DOCKER_USERNAME ?= x
 DOCKER_PASSWORD ?= x
 
-# Used by local integration test
-RESTYLER_GITHUB_APP_KEY ?= \
-  $(HOME)/downloads/restyled/restyled-io-development.2017-09-19.private-key.pem
-
 all: setup build lint test
 
 release: clean build lint test test.core image.build image.release
@@ -40,20 +36,14 @@ test:
 test.core:
 	cram test/core
 
-# Restyles restyled-io/demo#1
 .PHONY: test.integration
 test.integration: image.build
 	docker run --rm \
 	  --env DEBUG=1 \
+	  --env GITHUB_ACCESS_TOKEN \
 	  --volume /tmp:/tmp \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
-	  "$(LOCAL_IMAGE)" \
-	    --github-app-id 5355 \
-	    --github-app-key "$$(< "$(RESTYLER_GITHUB_APP_KEY)")" \
-	    --installation-id 58920 \
-	    --owner restyled-io \
-	    --repo demo \
-	    --pull-request 1
+	  "$(LOCAL_IMAGE)" "restyled-io/demo#1"
 
 .PHONY: install
 install:

--- a/README.md
+++ b/README.md
@@ -4,26 +4,19 @@ The restyling process, as a CLI.
 
 ## Usage
 
-To restyle a given Pull Request, you would need:
-
-1. The GitHub App Id
-1. The contents of that App's PEM private key
-1. The Installation Id for the Repository's installed instance of that App
-1. The Repository Owner and Name (e.g. `restyled.io/demo`)
-1. The Pull Request Number to restyle
-
 ```console
 docker run --rm \
+  --env "GITHUB_ACCESS_TOKEN=<access-token>" \
   --volume /tmp:tmp \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  restyled/restyler \
-    --github-app-id ... \
-    --github-app-key ... \
-    --installation-id ... \
-    --owner ... \
-    --repo ... \
-    --pull-request ...
+  restyled/restyler "<owner>/<name>#<number>"
 ```
+
+**NOTE**: The Access Token you use will determine some of the resulting
+behavior. In production, we use a token provisioned for an installed instance of
+our GitHub App, which ensures the restyled PRs and comments appear as authored
+by our App. If you use a Personal Access Token, the restyled PRs and comments
+will be authored by your user.
 
 ## Development
 
@@ -52,7 +45,7 @@ make test.core
 End-to-end test that restyles a public Pull Request in our `demo` Repository:
 
 ```console
-make test.integration
+make test.integration GITHUB_ACCESS_TOKEN=$(bin/get-access-token)
 ```
 
 ## Release

--- a/bin/get-access-token
+++ b/bin/get-access-token
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+#
+# Get an Access Token for our development GitHub App installed in the
+# restyled-io Org. Uses rubby because it was simple enough to copy the
+# documentatation.
+#
+# - https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-a-github-app
+# - https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-an-installation
+#
+####
+require "jwt"
+require "openssl"
+
+APP_ID = 5355
+APP_KEY = File.expand_path(
+  File.join(
+    "~/downloads/restyled",
+    "restyled-io-development.2017-09-19.private-key.pem",
+  )
+)
+INSTALLATION_ID = 58920
+
+jwt = JWT.encode(
+  {
+    iat: Time.now.to_i,
+    exp: Time.now.to_i + (10 * 60),
+    iss: APP_ID,
+  },
+  OpenSSL::PKey::RSA.new(File.read(APP_KEY)),
+  "RS256",
+)
+
+opts = [
+  "--silent", "-X", "POST",
+  "-H", "Authorization: Bearer #{jwt}",
+  "-H", "Accept: application/vnd.github.machine-man-preview+json",
+  "https://api.github.com/installations/#{INSTALLATION_ID}/access_tokens"
+]
+
+puts JSON.parse(`curl #{opts.map { |x| "'#{x}'" }.join(" ")}`).fetch("token")

--- a/package.yaml
+++ b/package.yaml
@@ -17,8 +17,8 @@ library:
     - bytestring
     - classy-prelude
     - directory
-    - errors
     - envparse
+    - errors
     - filepath
     - github
     - http-client
@@ -26,8 +26,8 @@ library:
     - http-types
     - jwt
     - megaparsec
-    - mtl
     - monad-logger
+    - mtl
     - operational
     - optparse-applicative
     - process
@@ -76,7 +76,6 @@ tests:
       - hspec
       - process
       - restyler
-      - shakespeare
       - temporary
       - text
       - yaml

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ library:
     - http-client-tls
     - http-types
     - jwt
+    - megaparsec
     - mtl
     - monad-logger
     - operational
@@ -71,6 +72,7 @@ tests:
       - restyler
       - classy-prelude
       - directory
+      - github
       - hspec
       - process
       - shakespeare

--- a/package.yaml
+++ b/package.yaml
@@ -69,12 +69,14 @@ tests:
     source-dirs: test
     ghc-options: -Wall
     dependencies:
-      - restyler
+      - bytestring
       - classy-prelude
       - directory
       - github
       - hspec
       - process
+      - restyler
       - shakespeare
       - temporary
       - text
+      - yaml

--- a/src/Restyler/Options.hs
+++ b/src/Restyler/Options.hs
@@ -26,13 +26,14 @@ data Options = Options
 
 parseRealOptions :: IO Options
 parseRealOptions = do
-    accessToken <- Env.parse id
+    accessToken <-
+        Env.parse id
         $ Env.var (Env.str <=< Env.nonempty) "GITHUB_ACCESS_TOKEN"
         $ Env.help "GitHub access token with write access to the repository"
 
-    RepoSpec{..} <- execParser
-        $ info (optionsParser <**> helper)
-        $ fullDesc <> progDesc "Restyle a GitHub Pull Request"
+    RepoSpec {..} <-
+        execParser $ info (optionsParser <**> helper) $ fullDesc <> progDesc
+            "Restyle a GitHub Pull Request"
 
     pure Options
         { oAccessToken = accessToken
@@ -42,8 +43,9 @@ parseRealOptions = do
         }
   where
     optionsParser :: Parser RepoSpec
-    optionsParser = argument (eitherReader parseRepoSpec)
-        (  metavar "<owner>/<name>#<number>"
+    optionsParser = argument
+        (eitherReader parseRepoSpec)
+        (metavar "<owner>/<name>#<number>"
         <> help "Repository and Pull Request to restyle"
         )
 
@@ -70,7 +72,7 @@ data Options' = Options'
 
 parseLegacyOptions :: IO Options
 parseLegacyOptions = do
-    Options'{..} <- parseOptions'
+    Options' {..} <- parseOptions'
     accessToken <- createAccessToken
         oGitHubAppId'
         oGitHubAppKey'
@@ -84,44 +86,43 @@ parseLegacyOptions = do
         }
 
 options :: Parser Options'
-options = Options'
-    <$> (mkId Proxy <$> option auto
-        (  long "github-app-id"
-        <> metavar "ID"
-        <> help "GitHub App Id"
-        ))
-    <*> (pack <$> strOption
-        (  long "github-app-key"
-        <> metavar "KEY"
-        <> help "GitHub App Key"
-        ))
-    <*> (mkId Proxy <$> option auto
-        (  long "installation-id"
-        <> metavar "ID"
-        <> help "Installation Id"
-        ))
-    <*> (mkName Proxy . pack <$> strOption
-        (  long "owner"
-        <> metavar "NAME"
-        <> help "Owner"
-        ))
-    <*> (mkName Proxy . pack <$> strOption
-        (  long "repo"
-        <> metavar "NAME"
-        <> help "Repo"
-        ))
-    <*> (mkId Proxy <$> option auto
-        (  long "pull-request"
-        <> metavar "NUMBER"
-        <> help "Pull Request"
-        ))
-    <*> (pack <$> strOption
-        (  long "restyled-root"
-        <> metavar "URL"
-        <> help "Root for restyled.io"
-        <> value "https://restyled.io"
-        ))
+options =
+    Options'
+        <$> (mkId Proxy <$> option
+                auto
+                (long "github-app-id" <> metavar "ID" <> help "GitHub App Id")
+            )
+        <*> (pack
+            <$> strOption
+                    (long "github-app-key" <> metavar "KEY" <> help
+                        "GitHub App Key"
+                    )
+            )
+        <*> (mkId Proxy <$> option
+                auto
+                (long "installation-id" <> metavar "ID" <> help
+                    "Installation Id"
+                )
+            )
+        <*> (mkName Proxy . pack <$> strOption
+                (long "owner" <> metavar "NAME" <> help "Owner")
+            )
+        <*> (mkName Proxy . pack <$> strOption
+                (long "repo" <> metavar "NAME" <> help "Repo")
+            )
+        <*> (mkId Proxy <$> option
+                auto
+                (long "pull-request" <> metavar "NUMBER" <> help "Pull Request")
+            )
+        <*> (pack <$> strOption
+                (long "restyled-root"
+                <> metavar "URL"
+                <> help "Root for restyled.io"
+                <> value "https://restyled.io"
+                )
+            )
 
 parseOptions' :: IO Options'
-parseOptions' = execParser $ info (options <**> helper)
+parseOptions' = execParser $ info
+    (options <**> helper)
     (fullDesc <> progDesc "Restyle a GitHub Pull Request")

--- a/src/Restyler/RepoSpec.hs
+++ b/src/Restyler/RepoSpec.hs
@@ -26,10 +26,11 @@ parseRepoSpec = first show . parse parser "<input>"
 type Parser = Parsec Void String
 
 parser :: Parser RepoSpec
-parser = RepoSpec
-    <$> (mkName Proxy . T.pack <$> manyTill nonSpace (char '/'))
-    <*> (mkName Proxy . T.pack <$> manyTill nonSpace (char '#'))
-    <*> (mkId Proxy . read <$> some digitChar)
+parser =
+    RepoSpec
+        <$> (mkName Proxy . T.pack <$> manyTill nonSpace (char '/'))
+        <*> (mkName Proxy . T.pack <$> manyTill nonSpace (char '#'))
+        <*> (mkId Proxy . read <$> some digitChar)
 
 nonSpace :: Parser Char
 nonSpace = satisfy $ not . isSpace

--- a/src/Restyler/RepoSpec.hs
+++ b/src/Restyler/RepoSpec.hs
@@ -1,0 +1,35 @@
+module Restyler.RepoSpec
+    ( RepoSpec(..)
+    , parseRepoSpec
+    ) where
+
+import Data.Bifunctor (first)
+import Data.Char (isSpace)
+import Data.Proxy
+import qualified Data.Text as T
+import Data.Void
+import GitHub.Data
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+data RepoSpec = RepoSpec
+    { rsOwner :: Name Owner
+    , rsRepo :: Name Repo
+    , rsPullRequest :: Id PullRequest
+    }
+    deriving (Eq, Show)
+
+-- | Parse @<owner>\/<name>#<number>@ into a @'RepoSpec'@
+parseRepoSpec :: String -> Either String RepoSpec
+parseRepoSpec = first show . parse parser "<input>"
+
+type Parser = Parsec Void String
+
+parser :: Parser RepoSpec
+parser = RepoSpec
+    <$> (mkName Proxy . T.pack <$> manyTill nonSpace (char '/'))
+    <*> (mkName Proxy . T.pack <$> manyTill nonSpace (char '#'))
+    <*> (mkId Proxy . read <$> some digitChar)
+
+nonSpace :: Parser Char
+nonSpace = satisfy $ not . isSpace

--- a/test/Restyler/CloneSpec.hs
+++ b/test/Restyler/CloneSpec.hs
@@ -5,6 +5,10 @@ module Restyler.CloneSpec (spec) where
 import SpecHelper
 
 import Restyler.Clone
+import Restyler.Process (callProcess)
+import System.Directory (setCurrentDirectory)
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readProcess)
 
 spec :: Spec
 spec = around (withSystemTempDirectory "") $ do
@@ -27,3 +31,9 @@ spec = around (withSystemTempDirectory "") $ do
             checkoutBranch True "develop"
             readProcess "git" ["rev-parse", "--abbrev-ref", "HEAD"] ""
                 `shouldReturn` "develop\n"
+
+setupGitRepo :: FilePath -> IO ()
+setupGitRepo dir = do
+    setCurrentDirectory dir
+    callProcess "git" ["init"]
+    callProcess "git" ["commit", "--allow-empty", "--message", "Test"]

--- a/test/Restyler/Config/InterpreterSpec.hs
+++ b/test/Restyler/Config/InterpreterSpec.hs
@@ -9,6 +9,8 @@ import SpecHelper
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Restyler.Config.Interpreter
+import System.Directory (removeFile)
+import System.IO.Temp (emptySystemTempFile)
 
 spec :: Spec
 spec = around withEmptySystemTempFile $ do
@@ -37,3 +39,7 @@ spec = around withEmptySystemTempFile $ do
                 ]
 
             (tmp `hasInterpreter` Python) `shouldReturn` True
+
+
+withEmptySystemTempFile :: (FilePath -> IO a) -> IO a
+withEmptySystemTempFile = bracket (emptySystemTempFile "") removeFile

--- a/test/Restyler/Config/InterpreterSpec.hs
+++ b/test/Restyler/Config/InterpreterSpec.hs
@@ -16,27 +16,18 @@ spec :: Spec
 spec = around withEmptySystemTempFile $ do
     describe "hasIntepreter" $ do
         it "can find a direct executable" $ \tmp -> do
-            T.writeFile tmp $ T.unlines
-                [ "#!/bin/sh"
-                , "echo 1"
-                ]
+            T.writeFile tmp $ T.unlines ["#!/bin/sh", "echo 1"]
 
             (tmp `hasInterpreter` Sh) `shouldReturn` True
             (tmp `hasInterpreter` Bash) `shouldReturn` False
 
         it "can find a nested executable" $ \tmp -> do
-            T.writeFile tmp $ T.unlines
-                [ "#!/usr/local/bin/bash"
-                , "echo 1"
-                ]
+            T.writeFile tmp $ T.unlines ["#!/usr/local/bin/bash", "echo 1"]
 
             (tmp `hasInterpreter` Bash) `shouldReturn` True
 
         it "can find something via /usr/bin/env" $ \tmp -> do
-            T.writeFile tmp $ T.unlines
-                [ "#!/usr/bin/env python"
-                , "print 1"
-                ]
+            T.writeFile tmp $ T.unlines ["#!/usr/bin/env python", "print 1"]
 
             (tmp `hasInterpreter` Python) `shouldReturn` True
 

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -1,101 +1,102 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-module Restyler.ConfigSpec (spec) where
+
+module Restyler.ConfigSpec
+    ( spec
+    ) where
 
 import SpecHelper
 
-import qualified Data.Text.IO as T
+import qualified Data.ByteString.Char8 as C8
+import Data.Yaml (decodeEither)
 import Restyler.Config
 
 spec :: Spec
-spec = around withEmptySystemTempFile $ do
-    describe "loadConfigFrom" $ do
-        it "supports a simple, name-based syntax" $ \tmp -> do
-            result <- loadConfig' tmp [st|
-            ---
-            - stylish-haskell
-            - prettier
-            |]
+spec = do
+    it "supports a simple, name-based syntax" $ do
+        let result = decodeEither $ C8.unlines
+                [ "---"
+                , "- stylish-haskell"
+                , "- prettier"
+                ]
 
-            result `shouldBe` Right Config
-                { cEnabled = True
-                , cRestylers =
-                    [ unsafeNamedRestyler "stylish-haskell"
-                    , unsafeNamedRestyler "prettier"
-                    ]
-                }
+        result `shouldBe` Right Config
+            { cEnabled = True
+            , cRestylers =
+                [ unsafeNamedRestyler "stylish-haskell"
+                , unsafeNamedRestyler "prettier"
+                ]
+            }
 
-        it "has a setting for globally disabling" $ \tmp -> do
-            enabled <- (cEnabled <$>) <$> loadConfig' tmp [st|
-            ---
-            enabled: false
-            restylers:
-            - stylish-haskell
-            |]
+    it "has a setting for globally disabling" $ do
+        let result = decodeEither $ C8.unlines
+                [ "---"
+                , "enabled: false"
+                , "restylers:"
+                , "- stylish-haskell"
+                ]
 
-            enabled `shouldBe` Right False
+        fmap cEnabled result `shouldBe` Right False
 
-        it "allows re-configuring includes" $ \tmp -> do
-            result1 <- loadConfig' tmp [st|
-            ---
-            - stylish-haskell:
-                include:
-                - "**/*.lhs"
-            |]
+    it "allows re-configuring includes" $ do
+        let result1 = decodeEither $ C8.unlines
+                [ "---"
+                , "- stylish-haskell:"
+                , "    include:"
+                , "    - \"**/*.lhs\""
+                ]
 
-            result2 <- loadConfig' tmp [st|
-            ---
-            - stylish-haskell:
-                include:
-                - "**/*.lhs"
-            |]
+            result2 = decodeEither $ C8.unlines
+                [ "---"
+                , "- stylish-haskell:"
+                , "    include:"
+                , "    - \"**/*.lhs\""
+                ]
 
-            result3 <- loadConfig' tmp [st|
-            ---
-            restylers:
-            - stylish-haskell:
-                include:
-                - "**/*.lhs"
-            |]
+            result3 = decodeEither $ C8.unlines
+                [ "---"
+                , "restylers:"
+                , "- stylish-haskell:"
+                , "    include:"
+                , "    - \"**/*.lhs\""
+                ]
 
-            result1 `shouldBe` result2
-            result2 `shouldBe` result3
-            result3 `shouldBe` Right Config
-                { cEnabled = True
-                , cRestylers =
-                    [ (unsafeNamedRestyler "stylish-haskell")
-                        { rInclude = [Include "**/*.lhs"]
-                        }
-                    ]
-                }
+        result1 `shouldBe` result2
+        result2 `shouldBe` result3
+        result3 `shouldBe` Right Config
+            { cEnabled = True
+            , cRestylers =
+                [ (unsafeNamedRestyler "stylish-haskell")
+                    { rInclude = [Include "**/*.lhs"]
+                    }
+                ]
+            }
 
-        it "has good errors for unknown name" $ \tmp -> do
-            result1 <- loadConfig' tmp [st|
-            ---
-            - uknown-name
-            |]
+    it "has good errors for unknown name" $ do
+        let result1 = decodeEither $ C8.unlines
+                [ "---"
+                , "- uknown-name"
+                ]
 
-            result2 <- loadConfig' tmp [st|
-            ---
-            - uknown-name:
-                arguments:
-                - --foo
-            |]
+            result2 = decodeEither $ C8.unlines
+                [ "---"
+                , "- uknown-name:"
+                , "    arguments:"
+                , "    - --foo"
+                ]
 
-            result3 <- loadConfig' tmp [st|
-            ---
-            restylers:
-            - uknown-name:
-                arguments:
-                - --foo
-            |]
+            result3 = decodeEither $ C8.unlines
+                [ "---"
+                , "restylers:"
+                , "- uknown-name:"
+                , "    arguments:"
+                , "    - --foo"
+                ]
 
-            result1 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
-            result2 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
-            result3 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
+        result1 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
+        result2 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
+        result3 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
 
-loadConfig' :: FilePath -> Text -> IO (Either String Config)
-loadConfig' fp yaml = do
-    T.writeFile fp $ dedent yaml
-    loadConfigFrom fp
+hasError :: String -> Either String Config -> Bool
+hasError msg (Left err) = msg `isInfixOf` err
+hasError _ _ = False

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -14,44 +14,43 @@ import Restyler.Config
 spec :: Spec
 spec = do
     it "supports a simple, name-based syntax" $ do
-        let result = decodeEither $ C8.unlines
-                [ "---"
-                , "- stylish-haskell"
-                , "- prettier"
-                ]
+        let
+            result = decodeEither
+                $ C8.unlines ["---", "- stylish-haskell", "- prettier"]
 
         result `shouldBe` Right Config
             { cEnabled = True
-            , cRestylers =
-                [ unsafeNamedRestyler "stylish-haskell"
-                , unsafeNamedRestyler "prettier"
-                ]
+            , cRestylers = [ unsafeNamedRestyler "stylish-haskell"
+                           , unsafeNamedRestyler "prettier"
+                           ]
             }
 
     it "has a setting for globally disabling" $ do
-        let result = decodeEither $ C8.unlines
-                [ "---"
-                , "enabled: false"
-                , "restylers:"
-                , "- stylish-haskell"
-                ]
+        let
+            result = decodeEither $ C8.unlines
+                ["---", "enabled: false", "restylers:", "- stylish-haskell"]
 
         fmap cEnabled result `shouldBe` Right False
 
     it "allows re-configuring includes" $ do
-        let result1 = decodeEither $ C8.unlines
-                [ "---"
-                , "- stylish-haskell:"
-                , "    include:"
-                , "    - \"**/*.lhs\""
-                ]
+        let
+            result1 =
+                decodeEither
+                    $ C8.unlines
+                          [ "---"
+                          , "- stylish-haskell:"
+                          , "    include:"
+                          , "    - \"**/*.lhs\""
+                          ]
 
-            result2 = decodeEither $ C8.unlines
-                [ "---"
-                , "- stylish-haskell:"
-                , "    include:"
-                , "    - \"**/*.lhs\""
-                ]
+            result2 =
+                decodeEither
+                    $ C8.unlines
+                          [ "---"
+                          , "- stylish-haskell:"
+                          , "    include:"
+                          , "    - \"**/*.lhs\""
+                          ]
 
             result3 = decodeEither $ C8.unlines
                 [ "---"
@@ -65,25 +64,18 @@ spec = do
         result2 `shouldBe` result3
         result3 `shouldBe` Right Config
             { cEnabled = True
-            , cRestylers =
-                [ (unsafeNamedRestyler "stylish-haskell")
-                    { rInclude = [Include "**/*.lhs"]
-                    }
-                ]
+            , cRestylers = [ (unsafeNamedRestyler "stylish-haskell")
+                                 { rInclude = [Include "**/*.lhs"]
+                                 }
+                           ]
             }
 
     it "has good errors for unknown name" $ do
-        let result1 = decodeEither $ C8.unlines
-                [ "---"
-                , "- uknown-name"
-                ]
+        let
+            result1 = decodeEither $ C8.unlines ["---", "- uknown-name"]
 
             result2 = decodeEither $ C8.unlines
-                [ "---"
-                , "- uknown-name:"
-                , "    arguments:"
-                , "    - --foo"
-                ]
+                ["---", "- uknown-name:", "    arguments:", "    - --foo"]
 
             result3 = decodeEither $ C8.unlines
                 [ "---"

--- a/test/Restyler/RepoSpecSpec.hs
+++ b/test/Restyler/RepoSpecSpec.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Restyler.RepoSpecSpec
+    ( spec
+    ) where
+
+import SpecHelper
+
+import Restyler.RepoSpec
+
+spec :: Spec
+spec = describe "parseRepoSpec" $ do
+    it "parses correctly" $ do
+        parseRepoSpec "foo/bar#1" `shouldBe` Right (RepoSpec "foo" "bar" 1)
+        parseRepoSpec "baz/bat#2" `shouldBe` Right (RepoSpec "baz" "bat" 2)
+
+    it "errors" $ do
+        parseRepoSpec "foo/bar" `shouldSatisfy` isLeft
+        parseRepoSpec "bar#2" `shouldSatisfy` isLeft
+        parseRepoSpec "foo/bar#baz" `shouldSatisfy` isLeft

--- a/test/Restyler/RepoSpecSpec.hs
+++ b/test/Restyler/RepoSpecSpec.hs
@@ -18,3 +18,7 @@ spec = describe "parseRepoSpec" $ do
         parseRepoSpec "foo/bar" `shouldSatisfy` isLeft
         parseRepoSpec "bar#2" `shouldSatisfy` isLeft
         parseRepoSpec "foo/bar#baz" `shouldSatisfy` isLeft
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -3,24 +3,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module SpecHelper
-    ( module SpecHelper
-    , module X
-    )
-    where
+    ( module X
+    ) where
 
-import ClassyPrelude as X hiding (dropEnd)
-
-import Data.Char (isSpace)
-import Data.Proxy
-import qualified Data.Text as T
-import GitHub.Data (Id, mkId)
-import qualified Prelude as P
-import Restyler.Process as X (callProcess)
-import System.Directory (removeFile, setCurrentDirectory)
-import System.IO.Temp as X (emptySystemTempFile, withSystemTempDirectory)
-import System.Process as X (readProcess)
+import ClassyPrelude as X
 import Test.Hspec as X
-import Text.Shakespeare.Text as X (st)
+
+import Data.Proxy
+import GitHub.Data (Id, mkId)
 
 instance Num (Id a) where
     -- Just so we can type literals for Ids in Specs
@@ -31,41 +21,3 @@ instance Num (Id a) where
     (*) = error "NO"
     abs = error "NO"
     signum = error "NO"
-
-setupGitRepo :: FilePath -> IO ()
-setupGitRepo dir = do
-    setCurrentDirectory dir
-    callProcess "git" ["init"]
-    callProcess "git" ["commit", "--allow-empty", "--message", "Test"]
-
--- | Dedent content
---
--- N.B. assumes an initial "\n" and trailing quote-end, which is what happens
--- when you use the st quasi-quoter in the following style:
---
--- > [st|
--- >   some code
--- >   some code
--- >   |]
---
--- In other words, do not use this on (e.g.) @\"Some text\n\"@
---
-dedent :: Text -> Text
-dedent t = T.unlines $ map (T.drop $ indent lns) lns
-  where
-    lns = dropEnd $ T.lines $ T.drop 1 t
-    dropEnd = reverse . drop 1 . reverse
-
-    indent [] = 0
-    indent ts = P.minimum $ map (T.length . T.takeWhile isSpace) ts
-
-withEmptySystemTempFile :: (FilePath -> IO a) -> IO a
-withEmptySystemTempFile = bracket (emptySystemTempFile "") removeFile
-
-hasError :: String -> Either String b -> Bool
-hasError msg (Left err) = msg `isInfixOf` err
-hasError _ _ = False
-
-isLeft :: Either a b -> Bool
-isLeft (Left _) = True
-isLeft _ = False

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module SpecHelper
     ( module SpecHelper
     , module X
@@ -9,7 +11,9 @@ module SpecHelper
 import ClassyPrelude as X hiding (dropEnd)
 
 import Data.Char (isSpace)
+import Data.Proxy
 import qualified Data.Text as T
+import GitHub.Data (Id, mkId)
 import qualified Prelude as P
 import Restyler.Process as X (callProcess)
 import System.Directory (removeFile, setCurrentDirectory)
@@ -17,6 +21,16 @@ import System.IO.Temp as X (emptySystemTempFile, withSystemTempDirectory)
 import System.Process as X (readProcess)
 import Test.Hspec as X
 import Text.Shakespeare.Text as X (st)
+
+instance Num (Id a) where
+    -- Just so we can type literals for Ids in Specs
+    fromInteger = mkId Proxy . fromInteger
+
+    (+) = error "NO"
+    (-) = error "NO"
+    (*) = error "NO"
+    abs = error "NO"
+    signum = error "NO"
 
 setupGitRepo :: FilePath -> IO ()
 setupGitRepo dir = do
@@ -51,3 +65,7 @@ withEmptySystemTempFile = bracket (emptySystemTempFile "") removeFile
 hasError :: String -> Either String b -> Bool
 hasError msg (Left err) = msg `isInfixOf` err
 hasError _ _ = False
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False


### PR DESCRIPTION
To accomplish this, we'll also just hard-code production root. We do still
need to parse the option since the Backend will continue to pass one for
now.

See restyled-io/restyled.io#55.