### PR TITLE
Add a layer of validation to configuration

### DIFF
--- a/src/Restyler/Model/Config.hs
+++ b/src/Restyler/Model/Config.hs
@@ -14,6 +14,7 @@ import Data.Aeson
 import Data.Aeson.Casing
 import Data.Aeson.Types (typeMismatch)
 import qualified Data.Vector as V
+import Restyler.Model.Config.ExpectedKeys
 import Restyler.Model.RemoteFile
 import Restyler.Model.Restyler
 import Restyler.Model.StatusesConfig
@@ -37,13 +38,15 @@ instance FromJSON Config where
     parseJSON (Array v) = do
         restylers <- mapM parseJSON (V.toList v)
         pure defaultConfig { cRestylers = restylers }
-    parseJSON (Object o) = Config
-        -- Use default values if un-specified
-        <$> o .:? "enabled" .!= cEnabled defaultConfig
-        <*> o .:? "auto" .!= cAuto defaultConfig
-        <*> o .:? "remote_files" .!= cRemoteFiles defaultConfig
-        <*> o .:? "statuses" .!= cStatusesConfig defaultConfig
-        <*> o .:? "restylers" .!= cRestylers defaultConfig
+    parseJSON (Object o) = do
+        validateObjectKeys
+            ["enabled", "auto", "remote_files", "statuses", "restylers"] o
+        Config
+            <$> o .:? "enabled" .!= cEnabled defaultConfig
+            <*> o .:? "auto" .!= cAuto defaultConfig
+            <*> o .:? "remote_files" .!= cRemoteFiles defaultConfig
+            <*> o .:? "statuses" .!= cStatusesConfig defaultConfig
+            <*> o .:? "restylers" .!= cRestylers defaultConfig
     parseJSON v = typeMismatch "Config object or list of restylers" v
 
 instance ToJSON Config where

--- a/src/Restyler/Model/Config/ExpectedKeys.hs
+++ b/src/Restyler/Model/Config/ExpectedKeys.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Restyler.Model.Config.ExpectedKeys
+    ( validateObjectKeys
+    , validateExpectedKeyBy
+    ) where
+
+import Restyler.Prelude
+
+import Data.Aeson.Types (Parser)
+import Data.Either (lefts)
+import Data.Function (on)
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM
+import qualified Prelude as Unsafe
+
+-- | Validate there are no unexpected keys in an Object
+--
+-- This is provided for convenience in the most common use-case. For a more
+-- flexible interface, see @'validateExpectedKeyBy'@.
+--
+validateObjectKeys :: [String] -> HashMap Text v -> Parser ()
+validateObjectKeys ks =
+    toParser
+        . lefts
+        . map (validateExpectedKeyBy "key" id ks)
+        . map unpack
+        . HM.keys
+  where
+    toParser [] = pure ()
+    toParser xs = fail $ unlines $ map ("- " <>) xs
+
+-- | Validate that a key is present in a list of (projected) items
+--
+-- Returns the item found when validation passes.
+--
+-- N.B. the @[c]@ values are almost always going to be @'String'@. It's typed as
+-- a list of @c@ because the only actual requirement is that there are equatable
+-- elements so we can compute edit-distances.
+--
+-- >>> validateExpectedKeyBy "key" fst [("foo", 1), ("bar", 2)] ("foo" :: String)
+-- Right ("foo",1)
+--
+validateExpectedKeyBy
+    :: (Eq c, Show c)
+    => String -- ^ The label to show as /Unknown \<label> .../
+    -> (a -> [c])
+    -- ^ A function to project each valid value as a comparable key
+    -> [a] -- ^ The input list of valid items
+    -> [c] -- ^ The input key
+    -> Either String a
+validateExpectedKeyBy label f as k = note msg $ find ((== k) . f) as
+  where
+    ks = map f as
+    msg = "Unexpected " <> label <> " " <> show k <> ", " <> maybe
+        ("must be one of " <> show ks <> ".")
+        (("did you mean " <>) . (<> "?") . show)
+        (do
+            (k', d) <- nearestElem k ks
+            guard $ d <= length k `div` 2
+            pure k'
+        )
+
+nearestElem :: Eq a => [a] -> [[a]] -> Maybe ([a], Int)
+nearestElem x = minimumBy (compare `on` snd) . map (id &&& editDistance x)
+
+-- | Calculate the edit-distance between two words
+--
+-- From <https://wiki.haskell.org/Edit_distance>; I do not understand it.
+--
+-- Lightly modified (linted and auto-formatted).
+--
+editDistance :: Eq a => [a] -> [a] -> Int
+editDistance a b = Unsafe.last $ if lab == 0
+    then mainDiag
+    else if lab > 0 then lowers !! (lab - 1) else uppers !! (-1 - lab)
+  where
+    mainDiag = oneDiag a b (Unsafe.head uppers) (-1 : Unsafe.head lowers)
+    uppers = eachDiag a b (mainDiag : uppers) -- upper diagonals
+    lowers = eachDiag b a (mainDiag : lowers) -- lower diagonals
+    eachDiag _ [] _ = []
+    eachDiag _ _ [] = []
+    eachDiag _ (_ : bs) (lastDiag : diags) =
+        oneDiag a bs nextDiag lastDiag : eachDiag a bs diags
+        where nextDiag = Unsafe.head (Unsafe.tail diags)
+    oneDiag _ _ diagAbove diagBelow = thisdiag
+      where
+        doDiag [] _ _ _ _ = []
+        doDiag _ [] _ _ _ = []
+        doDiag (ach : as) (bch : bs) nw n w = me
+            : doDiag as bs me (Unsafe.tail n) (Unsafe.tail w)
+          where
+            me = if ach == bch
+                then nw
+                else 1 + min3 (Unsafe.head w) nw (Unsafe.head n)
+        firstelt = 1 + Unsafe.head diagBelow
+        thisdiag =
+            firstelt : doDiag a b firstelt diagAbove (Unsafe.tail diagBelow)
+    lab = length a - length b
+    min3 x y z = if x < y then x else min y z

--- a/src/Restyler/Model/RemoteFile.hs
+++ b/src/Restyler/Model/RemoteFile.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Restyler.Model.RemoteFile
     ( RemoteFile(..)
@@ -8,6 +9,7 @@ import Restyler.Prelude
 
 import Data.Aeson
 import Data.Aeson.Casing
+import Restyler.Model.Config.ExpectedKeys
 
 -- | A remote (configuration) file, to fetch before restyling
 data RemoteFile = RemoteFile
@@ -17,7 +19,11 @@ data RemoteFile = RemoteFile
     deriving (Eq, Show, Generic)
 
 instance FromJSON RemoteFile where
-    parseJSON = genericParseJSON $ aesonPrefix snakeCase
+    parseJSON = withObject "RemoteFile" $ \o -> do
+        validateObjectKeys ["url", "path"] o
+        RemoteFile
+            <$> o .: "url"
+            <*> o .: "path"
 
 instance ToJSON RemoteFile where
     toJSON = genericToJSON $ aesonPrefix snakeCase

--- a/src/Restyler/Model/StatusesConfig.hs
+++ b/src/Restyler/Model/StatusesConfig.hs
@@ -14,6 +14,7 @@ import Data.Aeson
 import Data.Aeson.Casing
 import Data.Aeson.Types (typeMismatch)
 import qualified Data.Aeson.Types as Aeson
+import Restyler.Model.Config.ExpectedKeys
 
 -- | Configuration for sending PR statuses
 data StatusesConfig = StatusesConfig
@@ -27,10 +28,12 @@ data StatusesConfig = StatusesConfig
     deriving (Eq, Show, Generic)
 
 instance FromJSON StatusesConfig where
-    parseJSON (Object o) = StatusesConfig
-        <$> o .:? "differences" .!= scDifferences
-        <*> o .:? "no-differences" .!= scNoDifferences
-        <*> o .:? "error" .!= scError
+    parseJSON (Object o) = do
+        validateObjectKeys ["differences", "no-differences", "error"] o
+        StatusesConfig
+            <$> o .:? "differences" .!= scDifferences
+            <*> o .:? "no-differences" .!= scNoDifferences
+            <*> o .:? "error" .!= scError
       where
         StatusesConfig{..} = defaultStatusesConfig
     parseJSON (Aeson.Bool b) = pure StatusesConfig

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -19,7 +19,7 @@ import Control.Monad.Logger as X
 import Control.Monad.Reader as X
 import Data.Bifunctor as X
 import Data.Char as X (isSpace)
-import Data.Foldable as X
+import Data.Foldable as X hiding (maximumBy, minimumBy)
 import Data.List as X
     (dropWhileEnd, find, foldl', isInfixOf, isPrefixOf, isSuffixOf)
 import Data.Maybe as X hiding (fromJust)
@@ -38,6 +38,7 @@ import Safe as X
 --------------------------------------------------------------------------------
 -- Globally-useful utilities
 --------------------------------------------------------------------------------
+import qualified Data.Foldable as F
 import qualified Data.Text as T
 
 -- | @'when'@ with a monadic condition
@@ -68,3 +69,11 @@ infixl 4 <$$>
 -- | @'fmap'@ for doubly-wrapped values
 (<$$>) :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
 f <$$> a = fmap f <$> a
+
+minimumBy :: (a -> a -> Ordering) -> [a] -> Maybe a
+minimumBy _ [] = Nothing
+minimumBy f xs = Just $ F.minimumBy f xs
+
+maximumBy :: (a -> a -> Ordering) -> [a] -> Maybe a
+maximumBy _ [] = Nothing
+maximumBy f xs = Just $ F.maximumBy f xs

--- a/test/Restyler/Model/Config/ExpectedKeysSpec.hs
+++ b/test/Restyler/Model/Config/ExpectedKeysSpec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Restyler.Model.Config.ExpectedKeysSpec
+    ( spec
+    )
+where
+
+import SpecHelper
+
+import Restyler.Model.Config.ExpectedKeys
+
+spec :: Spec
+spec = do
+    describe "validateExpectedKeyBy" $ do
+        let validate = validateExpectedKeyBy "key" id
+
+        it "accepts expected keys" $ do
+            validate ["foo"] "foo" `shouldBe` Right "foo"
+            validate ["foo", "bar"] "foo" `shouldBe` Right "foo"
+            validate ["bar", "foo"] "foo" `shouldBe` Right "foo"
+            validate ["foo", "foo"] "foo" `shouldBe` Right "foo"
+
+        it "rejects with a default message" $ do
+            let
+                msg =
+                    "Unexpected key \"bxx\", must be one of [\"foo\",\"bar\"]."
+
+            validate ["foo", "bar"] "bxx" `shouldBe` Left msg
+
+        it "suggests based on edit-distance" $ do
+            let msg = "Unexpected key \"baz\", did you mean \"bar\"?"
+
+            validate ["foo", "bar"] "baz" `shouldBe` Left msg

--- a/test/Restyler/Model/ConfigSpec.hs
+++ b/test/Restyler/Model/ConfigSpec.hs
@@ -86,9 +86,30 @@ spec = do
                 , "    - --foo"
                 ]
 
-        result1 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
-        result2 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
-        result3 `shouldSatisfy` hasError "Unknown restyler name: uknown-name"
+        result1 `shouldSatisfy` hasError "Unexpected restyler \"uknown-name\""
+        result2 `shouldSatisfy` hasError "Unexpected restyler \"uknown-name\""
+        result3 `shouldSatisfy` hasError "Unexpected restyler \"uknown-name\""
+
+    it "provides suggestions for close matches" $ do
+        let result1 = decodeEither $ C8.unlines ["---", "- hindex"]
+
+            result2 =
+                decodeEither $ C8.unlines
+                    ["---", "- hindex:", "    arguments:", "    - --foo"]
+
+            result3 =
+                decodeEither
+                    $ C8.unlines
+                          [ "---"
+                          , "restylers:"
+                          , "- hindex:"
+                          , "    arguments:"
+                          , "    - --foo"
+                          ]
+
+        result1 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
+        result2 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
+        result3 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
 
 hasError :: String -> Either String Config -> Bool
 hasError msg (Left err) = msg `isInfixOf` err


### PR DESCRIPTION
For objects that we parse in configuration, pre-validate that the keys of the
raw object are all known -- error if not. And include edit-distance-based
suggestions in the error message.

This came from a case where `includes` (not `include`) was used in a
configuration, which was silently ignored. The experience was not great. With
this fix, there would be a validation error that has _did you mean "include"?_
in the message -- pretty nice.

Unexpectedly, this was re-usable in namedRestyler too. So now a config with
(e.g.) `hindex` will get a nice hint, _did you mean "hindent"?_ instead of just
_unknown restyler name: hindex_.

This comes with two downsides:

- We can't use Generic for objects with this validation

  A minor annoyance, seems acceptable.

- We have to duplicate the keys in the expected list and the actual parse

  Not a big deal (IMO) because the two expressions will always be a line apart,
  so they're unlikely to drift. I.e. it's a write-time bother, but not a risk.