### PR TITLE
Support disabling comments

### DIFF
--- a/src/Restyler/Main.hs
+++ b/src/Restyler/Main.hs
@@ -99,7 +99,7 @@ run = do
             pure $ simplePullRequestHtmlUrl restyledPr
         Nothing -> do
             restyledPr <- createRestyledPullRequest $ rrRestylersRan result
-            leaveRestyledComment restyledPr
+            whenM commentsEnabled $ leaveRestyledComment restyledPr
             pure $ pullRequestHtmlUrl restyledPr
 
     sendPullRequestStatus $ DifferencesStatus restyledUrl
@@ -107,6 +107,9 @@ run = do
 
 configEnabled :: MonadReader App m => m Bool
 configEnabled = asks $ cEnabled . appConfig
+
+commentsEnabled :: MonadReader App m => m Bool
+commentsEnabled = asks $ cCommentsEnabled . appConfig
 
 restyle
     :: ( MonadSystem m

--- a/src/Restyler/Model/Config.hs
+++ b/src/Restyler/Model/Config.hs
@@ -27,6 +27,8 @@ data Config = Config
     -- ^ Just push the restyling, don't comment?
     , cRemoteFiles :: [RemoteFile]
     -- ^ Any remote configuration files to fetch before restyling
+    , cCommentsEnabled :: Bool
+    -- ^ Leave Comments?
     , cStatusesConfig :: StatusesConfig
     -- ^ Send PR statuses?
     , cRestylers :: [Restyler]
@@ -40,11 +42,12 @@ instance FromJSON Config where
         pure defaultConfig { cRestylers = restylers }
     parseJSON (Object o) = do
         validateObjectKeys
-            ["enabled", "auto", "remote_files", "statuses", "restylers"] o
+            ["enabled", "auto", "remote_files", "comments", "statuses", "restylers"] o
         Config
             <$> o .:? "enabled" .!= cEnabled defaultConfig
             <*> o .:? "auto" .!= cAuto defaultConfig
             <*> o .:? "remote_files" .!= cRemoteFiles defaultConfig
+            <*> o .:? "comments" .!= cCommentsEnabled defaultConfig
             <*> o .:? "statuses" .!= cStatusesConfig defaultConfig
             <*> o .:? "restylers" .!= cRestylers defaultConfig
     parseJSON v = typeMismatch "Config object or list of restylers" v
@@ -57,6 +60,7 @@ instance ToJSON Config where
 --
 -- - Enabled
 -- - Not Auto
+-- - Leave comments
 -- - Send statuses
 -- - Run most restylers
 --
@@ -65,6 +69,7 @@ defaultConfig = Config
     { cEnabled = True
     , cAuto = False
     , cRemoteFiles = []
+    , cCommentsEnabled = True
     , cStatusesConfig = defaultStatusesConfig
     , cRestylers = defaultRestylers
     }


### PR DESCRIPTION
For some, the PR statuses are enough but going auto:true would be too
implicit. This allows them to configure to a status-only work-flow.

For now, the default behavior is the same, but we may consider removing
comments in the future. To achieve that, we would probably need a way to
record what kind of configuration users are opting for and then
selecting the most popular behavior as the default.