### PR TITLE
Extract Git module

### DIFF
--- a/src/Restyler/App/Class.hs
+++ b/src/Restyler/App/Class.hs
@@ -94,8 +94,12 @@ instance MonadIO m => MonadApp (AppT m) where
         appIO SystemError Exit.exitSuccess
 
     callProcess cmd args = do
-        -- N.B. this injects access tokens into the logs when calling git-clone, but
-        -- that's OK because it's DEBUG and they're short-lived anyway.
+        -- N.B. this includes access tokens in log messages when used for
+        -- git-clone. That's acceptable because:
+        --
+        -- - These tokens are ephemeral (5 minutes)
+        -- - We generally accept secrets in DEBUG messages
+        --
         logDebugN $ pack $ "call: " <> cmd <> " " <> show args
         appIO SystemError $ Process.callProcess cmd args
 

--- a/src/Restyler/Git.hs
+++ b/src/Restyler/Git.hs
@@ -20,10 +20,12 @@ gitClone :: MonadApp m => String -> FilePath -> m ()
 gitClone url dir = callProcess "git" ["clone", url, dir]
 
 gitCheckout :: MonadApp m => String -> m ()
-gitCheckout branch = callProcess "git" ["checkout", "-b", branch]
+gitCheckout branch =
+    callProcess "git" ["checkout", "--no-progress", "-b", branch]
 
 gitCheckoutExisting :: MonadApp m => String -> m ()
-gitCheckoutExisting branch = callProcess "git" ["checkout", branch]
+gitCheckoutExisting branch =
+    callProcess "git" ["checkout", "--no-progress", branch]
 
 gitFetch :: MonadApp m => String -> String -> m ()
 gitFetch remoteRef localRef =

--- a/src/Restyler/Git.hs
+++ b/src/Restyler/Git.hs
@@ -1,0 +1,57 @@
+module Restyler.Git
+    ( gitClone
+    , gitCheckout
+    , gitCheckoutExisting
+    , gitFetch
+    , gitPush
+    , gitPushForce
+    , gitPushDelete
+    , gitMergeBase
+    , gitDiffNameOnly
+    , gitCommitAll
+    )
+where
+
+import Restyler.Prelude
+
+import Restyler.App
+
+gitClone :: MonadApp m => String -> FilePath -> m ()
+gitClone url dir = callProcess "git" ["clone", url, dir]
+
+gitCheckout :: MonadApp m => String -> m ()
+gitCheckout branch = callProcess "git" ["checkout", "-b", branch]
+
+gitCheckoutExisting :: MonadApp m => String -> m ()
+gitCheckoutExisting branch = callProcess "git" ["checkout", branch]
+
+gitFetch :: MonadApp m => String -> String -> m ()
+gitFetch remoteRef localRef =
+    callProcess "git" ["fetch", "origin", remoteRef <> ":" <> localRef]
+
+gitPush :: MonadApp m => String -> m ()
+gitPush branch = callProcess "git" ["push", "origin", branch]
+
+gitPushForce :: MonadApp m => String -> m ()
+gitPushForce branch =
+    callProcess "git" ["push", "--force-with-lease", "origin", branch]
+
+gitPushDelete :: MonadApp m => String -> m ()
+gitPushDelete branch = callProcess "git" ["push", "origin", "--delete", branch]
+
+gitMergeBase :: MonadApp m => String -> m (Maybe String)
+gitMergeBase branch = do
+    output <- readProcess "git" ["merge-base", branch, "HEAD"] ""
+    pure $ listToMaybe $ lines output
+
+gitDiffNameOnly :: MonadApp m => Maybe String -> m [FilePath]
+gitDiffNameOnly mRef = do
+    let args = ["diff", "--name-only"] <> maybeToList mRef
+    lines <$> readProcess "git" args ""
+
+gitCommitAll :: MonadApp m => String -> m String
+gitCommitAll msg = do
+    callProcess "git" ["commit", "-a", "--message", msg]
+
+    -- TODO: gross
+    unpack . chomp . pack <$> readProcess "git" ["rev-parse", "HEAD"] ""


### PR DESCRIPTION
Isolate all our git operations. Calling processes directly is a bit of a 
 smell, and perhaps some day these will be first-class in MonadApp so we can
 stub them in unit tests.