### PR TITLE
Support adding labels to Restyle PRs

### DIFF
--- a/src/Restyler/App/Class.hs
+++ b/src/Restyler/App/Class.hs
@@ -13,6 +13,7 @@ module Restyler.App.Class
     -- of the hidings we'd otherwise need to do at every import site.
     --
     , module GitHub.Endpoints.Issues.Comments
+    , module GitHub.Endpoints.Issues.Labels
     , module GitHub.Endpoints.PullRequests
     , module GitHub.Endpoints.Repos.Statuses
     ) where
@@ -24,6 +25,7 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Vector as V
 import GitHub.Endpoints.Issues.Comments hiding (comment, comments)
+import GitHub.Endpoints.Issues.Labels
 import GitHub.Endpoints.PullRequests hiding (pullRequest)
 import GitHub.Endpoints.Repos.Statuses
 import GitHub.Request

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -44,7 +44,15 @@ instance FromJSON Config where
         pure defaultConfig { cRestylers = restylers }
     parseJSON (Object o) = do
         validateObjectKeys
-            ["enabled", "auto", "remote_files", "comments", "statuses", "labels", "restylers"] o
+            [ "enabled"
+            , "auto"
+            , "remote_files"
+            , "comments"
+            , "statuses"
+            , "labels"
+            , "restylers"
+            ]
+            o
         Config
             <$> o .:? "enabled" .!= cEnabled defaultConfig
             <*> o .:? "auto" .!= cAuto defaultConfig

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -31,6 +31,8 @@ data Config = Config
     -- ^ Leave Comments?
     , cStatuses :: Statuses
     -- ^ Send PR statuses?
+    , cLabels :: [Name IssueLabel]
+    -- ^ Labels to add to Restyle PRs
     , cRestylers :: [Restyler]
     -- ^ What restylers to run
     }
@@ -42,13 +44,14 @@ instance FromJSON Config where
         pure defaultConfig { cRestylers = restylers }
     parseJSON (Object o) = do
         validateObjectKeys
-            ["enabled", "auto", "remote_files", "comments", "statuses", "restylers"] o
+            ["enabled", "auto", "remote_files", "comments", "statuses", "labels", "restylers"] o
         Config
             <$> o .:? "enabled" .!= cEnabled defaultConfig
             <*> o .:? "auto" .!= cAuto defaultConfig
             <*> o .:? "remote_files" .!= cRemoteFiles defaultConfig
             <*> o .:? "comments" .!= cCommentsEnabled defaultConfig
             <*> o .:? "statuses" .!= cStatuses defaultConfig
+            <*> o .:? "labels" .!= cLabels defaultConfig
             <*> o .:? "restylers" .!= cRestylers defaultConfig
     parseJSON v = typeMismatch "Config object or list of restylers" v
 
@@ -62,6 +65,7 @@ instance ToJSON Config where
 -- - Not Auto
 -- - Leave comments
 -- - Send statuses
+-- - No labels
 -- - Run most restylers
 --
 defaultConfig :: Config
@@ -71,6 +75,7 @@ defaultConfig = Config
     , cRemoteFiles = []
     , cCommentsEnabled = True
     , cStatuses = defaultStatusesConfig
+    , cLabels = []
     , cRestylers = defaultRestylers
     }
 

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -12,6 +12,7 @@ where
 import Restyler.Prelude
 
 import Restyler.App
+import Restyler.Config
 import qualified Restyler.Content as Content
 import Restyler.Git
 import Restyler.PullRequest
@@ -42,6 +43,14 @@ createRestyledPullRequest results = do
             , createPullRequestHead = pullRequestRestyledRef pullRequest
             , createPullRequestBase = pullRequestRestyledBase pullRequest
             }
+
+    labels <- asks $ cLabels . appConfig
+
+    unless (null labels) $ runGitHub_ $ addLabelsToIssueR
+        (pullRequestOwnerName pullRequest)
+        (pullRequestRepoName pullRequest)
+        (pullRequestIssueId pr)
+        labels
 
     pr <$ logInfoN ("Opened Restyled PR " <> showSpec (pullRequestSpec pr))
 

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -47,8 +47,8 @@ createRestyledPullRequest results = do
     labels <- asks $ cLabels . appConfig
 
     unless (null labels) $ runGitHub_ $ addLabelsToIssueR
-        (pullRequestOwnerName pullRequest)
-        (pullRequestRepoName pullRequest)
+        (pullRequestOwnerName pr)
+        (pullRequestRepoName pr)
         (pullRequestIssueId pr)
         labels
 


### PR DESCRIPTION
Introduces a new top-level configuration key:

```yaml
labels:
  - one
  - two
```

If present and non-empty, each of the defined labels will be added to
the newly-created "restyled" PR after it's opened. This can be used to
prevent normal PR automation from running on our sidecar PRs when it's
not appropriate.

Closes restyled-io/restyled.io#121.