### PR TITLE
Delete reference via API, not git

### DIFF
--- a/src/GitHub/Endpoints/GitData/References/Delete.hs
+++ b/src/GitHub/Endpoints/GitData/References/Delete.hs
@@ -1,0 +1,36 @@
+-- | <https://developer.github.com/v3/git/refs/#delete-a-reference>
+module GitHub.Endpoints.GitData.References.Delete
+    ( deleteReference
+    , deleteReferenceR
+    )
+where
+
+import Prelude
+
+import GitHub.Data
+import GitHub.Request
+
+deleteReference
+    :: Auth
+    -> Name Owner
+    -> Name Repo
+    -> Name GitReference
+    -> IO (Either Error ())
+deleteReference auth user repo ref =
+    executeRequest auth $ deleteReferenceR user repo ref
+
+deleteReferenceR
+    :: Name Owner
+    -> Name Repo
+    -> Name GitReference
+    -> GenRequest 'MtUnit 'RW ()
+deleteReferenceR user repo ref = Command Delete path mempty
+  where
+    path =
+        [ "repos"
+        , toPathPart user
+        , toPathPart repo
+        , "git"
+        , "refs"
+        , toPathPart ref
+        ]

--- a/src/GitHub/Request/Display.hs
+++ b/src/GitHub/Request/Display.hs
@@ -20,7 +20,7 @@ newtype DisplayGitHubRequest = DisplayGitHubRequest
 instance Show DisplayGitHubRequest where
     show = unpack . unDisplayGitHubRequest
 
-displayGitHubRequest :: Request k a -> DisplayGitHubRequest
+displayGitHubRequest :: GenRequest m k a -> DisplayGitHubRequest
 displayGitHubRequest = DisplayGitHubRequest . \case
     Query ps qs -> mconcat
         [ "[GET] "

--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -141,8 +141,6 @@ instance HasGit App where
     gitPush branch = callProcess "git" ["push", "origin", branch]
     gitPushForce branch =
         callProcess "git" ["push", "--force-with-lease", "origin", branch]
-    gitPushDelete branch =
-        callProcess "git" ["push", "origin", "--delete", branch]
     gitMergeBase branch = do
         output <- readProcess "git" ["merge-base", branch, "HEAD"] ""
         pure $ listToMaybe $ lines output

--- a/src/Restyler/App/Class.hs
+++ b/src/Restyler/App/Class.hs
@@ -20,8 +20,8 @@ module Restyler.App.Class
 
 import Restyler.Prelude
 
-import Data.Aeson
 import GitHub.Data.Request
+import GitHub.Request
 import Restyler.Config
 import Restyler.Options
 import Restyler.PullRequest
@@ -56,15 +56,16 @@ class HasDownloadFile env where
     downloadFile :: Text -> FilePath -> RIO env ()
 
 class HasGitHub env where
-    runGitHub :: FromJSON a => Request k a -> RIO env a
+    runGitHub :: ParseResponse m a => GenRequest m k a -> RIO env a
 
 -- | Fetch the first page using @'runGitHub'@, return the first item
 runGitHubFirst
-    :: (HasGitHub env, FromJSON a)
-    => (FetchCount -> Request k (Vector a))
+    :: (HasGitHub env, ParseResponse m (Vector a))
+    => (FetchCount -> GenRequest m k (Vector a))
     -> RIO env (Maybe a)
 runGitHubFirst f = (V.!? 0) <$> runGitHub (f 1)
 
 -- | @'void' . 'runGitHub'@
-runGitHub_ :: (HasGitHub env, FromJSON a) => Request k a -> RIO env ()
+runGitHub_
+    :: (HasGitHub env, ParseResponse m a) => GenRequest m k a -> RIO env ()
 runGitHub_ = void . runGitHub

--- a/src/Restyler/Git.hs
+++ b/src/Restyler/Git.hs
@@ -19,7 +19,6 @@ import Restyler.App.Class
 class HasGit env where
     gitPush :: String -> RIO env ()
     gitPushForce :: String -> RIO env ()
-    gitPushDelete :: String -> RIO env ()
     gitMergeBase :: String -> RIO env (Maybe String)
     gitDiffNameOnly :: Maybe String -> RIO env [FilePath]
     gitCommitAll :: String -> RIO env String

--- a/src/Restyler/Main.hs
+++ b/src/Restyler/Main.hs
@@ -25,6 +25,7 @@ restylerMain
        , HasSystem env
        , HasExit env
        , HasProcess env
+       , HasGit env
        , HasDownloadFile env
        , HasGitHub env
        )
@@ -79,6 +80,7 @@ restyle
        , HasPullRequest env
        , HasSystem env
        , HasProcess env
+       , HasGit env
        )
     => RIO env [RestylerResult]
 restyle = do
@@ -87,7 +89,7 @@ restyle = do
     pullRequestPaths <- changedPaths $ pullRequestBaseRef pullRequest
     runRestylers restylers pullRequestPaths
 
-changedPaths :: HasProcess env => Text -> RIO env [FilePath]
+changedPaths :: HasGit env => Text -> RIO env [FilePath]
 changedPaths branch = do
     ref <- maybe branch pack <$> gitMergeBase (unpack branch)
     gitDiffNameOnly $ Just $ unpack ref

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -9,6 +9,7 @@ where
 
 import Restyler.Prelude
 
+import GitHub.Endpoints.GitData.References.Delete
 import GitHub.Endpoints.Issues.Labels
 import GitHub.Endpoints.PullRequests hiding (pullRequest)
 import GitHub.Endpoints.PullRequests.ReviewRequests
@@ -129,10 +130,12 @@ closeRestyledPullRequest' pullRequest mRestyledPr =
                 , editPullRequestMaintainerCanModify = Nothing
                 }
 
-        -- FIXME: called not from in a Git repo!
-        -- let branch = pullRequestRestyledRef pullRequest
-        -- logInfo $ "Deleting restyled branch: " <> displayShow branch
-        -- gitPushDelete $ unpack branch
+        let branch = pullRequestRestyledRef pullRequest
+        logInfo $ "Deleting restyled branch: " <> displayShow branch
+        runGitHub_ $ deleteReferenceR
+            (pullRequestOwnerName pullRequest)
+            (pullRequestRepoName pullRequest)
+            (mkName Proxy $ "heads/" <> branch)
 
 -- | Commit and push to current branch
 updateOriginalPullRequest :: (HasPullRequest env, HasGit env) => RIO env ()

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -29,7 +29,7 @@ createRestyledPullRequest
        , HasOptions env
        , HasConfig env
        , HasPullRequest env
-       , HasProcess env
+       , HasGit env
        , HasGitHub env
        )
     => [RestylerResult]
@@ -80,7 +80,7 @@ createRestyledPullRequest results = do
     pr <$ logInfo ("Opened Restyled PR " <> displayShow (pullRequestSpec pr))
 
 -- | Commit and force-push to the (existing) restyled branch
-updateRestyledPullRequest :: (HasPullRequest env, HasProcess env) => RIO env ()
+updateRestyledPullRequest :: (HasPullRequest env, HasGit env) => RIO env ()
 updateRestyledPullRequest = do
     rBranch <- pullRequestRestyledRef <$> view pullRequestL
     gitPushForce $ unpack rBranch
@@ -88,7 +88,6 @@ updateRestyledPullRequest = do
 -- | Close the Restyled PR, if we know of it
 closeRestyledPullRequest
     :: ( HasLogFunc env
-       , HasProcess env
        , HasPullRequest env
        , HasRestyledPullRequest env
        , HasGitHub env
@@ -104,7 +103,7 @@ closeRestyledPullRequest = do
 
 -- | Extracted for use during Setup (e.g. without @'HasPullRequest'@)
 closeRestyledPullRequest'
-    :: (HasLogFunc env, HasProcess env, HasGitHub env)
+    :: (HasLogFunc env, HasGitHub env)
     => PullRequest
     -> Maybe SimplePullRequest
     -> RIO env ()
@@ -130,11 +129,12 @@ closeRestyledPullRequest' pullRequest mRestyledPr =
                 , editPullRequestMaintainerCanModify = Nothing
                 }
 
-        let branch = pullRequestRestyledRef pullRequest
-        logInfo $ "Deleting restyled branch: " <> displayShow branch
-        gitPushDelete $ unpack branch
+        -- FIXME: called not from in a Git repo!
+        -- let branch = pullRequestRestyledRef pullRequest
+        -- logInfo $ "Deleting restyled branch: " <> displayShow branch
+        -- gitPushDelete $ unpack branch
 
 -- | Commit and push to current branch
-updateOriginalPullRequest :: (HasPullRequest env, HasProcess env) => RIO env ()
+updateOriginalPullRequest :: (HasPullRequest env, HasGit env) => RIO env ()
 updateOriginalPullRequest =
     gitPush . unpack . pullRequestHeadRef =<< view pullRequestL

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -4,6 +4,7 @@ module Restyler.Restyler.Run
 
     -- * Exported for testing only
     , runRestyler
+    , runRestyler_
     , filterRestylePaths
     )
 where
@@ -15,12 +16,13 @@ import Restyler.App.Class
 import Restyler.App.Error
 import Restyler.Config.Include
 import Restyler.Config.Interpreter
+import Restyler.Git
 import Restyler.Restyler
 import Restyler.RestylerResult
 
 -- | Runs the given @'Restyler'@s over the files and report results
 runRestylers
-    :: (HasLogFunc env, HasSystem env, HasProcess env)
+    :: (HasLogFunc env, HasSystem env, HasProcess env, HasGit env)
     => [Restyler]
     -> [FilePath]
     -> RIO env [RestylerResult]
@@ -61,7 +63,7 @@ filterRestylePaths r = filterM (r `shouldRestyle`)
 
 -- | Run a @'Restyler'@ and get the result (i.e. commit changes)
 runRestyler
-    :: (HasLogFunc env, HasSystem env, HasProcess env)
+    :: (HasLogFunc env, HasSystem env, HasProcess env, HasGit env)
     => Restyler
     -> [FilePath]
     -> RIO env RestylerResult

--- a/src/Restyler/RestylerResult.hs
+++ b/src/Restyler/RestylerResult.hs
@@ -8,7 +8,6 @@ where
 
 import Restyler.Prelude
 
-import Restyler.App.Class
 import Restyler.Git
 import Restyler.Restyler
 
@@ -34,7 +33,7 @@ noPathsRestylerResult r = RestylerResult r NoPaths
 --
 -- N.B. This will create commits if appropriate.
 --
-getRestylerResult :: HasProcess env => Restyler -> RIO env RestylerResult
+getRestylerResult :: HasGit env => Restyler -> RIO env RestylerResult
 getRestylerResult r = RestylerResult r <$> getRestyleOutcome r
 
 -- | Does this @'RestylerResult'@ indicate changes were comitted?
@@ -44,7 +43,7 @@ restylerCommittedChanges = committedChanges . rrOutcome
     committedChanges (ChangesCommitted _ _) = True
     committedChanges _ = False
 
-getRestyleOutcome :: HasProcess env => Restyler -> RIO env RestyleOutcome
+getRestyleOutcome :: HasGit env => Restyler -> RIO env RestyleOutcome
 getRestyleOutcome restyler = do
     changedPaths <- gitDiffNameOnly Nothing
 

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -28,7 +28,7 @@ spec = do
 
             filtered `shouldBe` []
 
-    describe "runRestyler" $ do
+    describe "runRestyler_" $ do
         it "rescues exit code exceptions to RestylerError" $ do
             let errCallProcess _ _ =
                     mapAppError SystemError $ liftIO $ Process.callProcess
@@ -40,7 +40,7 @@ spec = do
                     , taCallProcess = errCallProcess
                     }
 
-            runTestApp (runRestyler someRestyler ["foo bar"])
+            runTestApp (runRestyler_ someRestyler ["foo bar"])
                 `shouldThrow` isRestylerError someRestyler errMessage
 
 isRestylerError :: Restyler -> String -> AppError -> Bool


### PR DESCRIPTION
We aren't in the git clone when cleaning up from a closed PR.