### PR TITLE
Implement global exclude configuration

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,6 +11,20 @@
 # Do anything at all?
 enabled: true
 
+# Patterns to exclude from all Restylers
+#
+# By default, we ignore directories that are often checked-in but rarely
+# represent project code. This glob is slightly complicated to match paths
+# within directories of these names appearing at any depth.
+#
+# This behavior can be disabled in your project with:
+#
+#   exclude: []
+#
+exclude:
+  - "**/node_modules/**/*"
+  - "**/vendor/**/*"
+
 # Push the style fixes directly to the original PR
 #
 # This setting implies pull_requests: false for origin PRs, and has no effect on

--- a/restyle-path/main.hs
+++ b/restyle-path/main.hs
@@ -6,7 +6,7 @@ import Conduit (runResourceT, sinkFile)
 import Data.Text (unpack)
 import Network.HTTP.Simple hiding (Request)
 import Restyler.App.Class (HasDownloadFile(..), HasProcess(..), HasSystem(..))
-import Restyler.Config (Config(..), loadConfig)
+import Restyler.Config (loadConfig)
 import Restyler.Options
 import Restyler.Restyler.Run (runRestylers_)
 import qualified RIO.Directory as Directory
@@ -50,7 +50,7 @@ main = do
     options <- setupLog <$> logOptionsHandle stdout verbose
     withLogFunc options $ \logFunc -> runRIO (setupApp logFunc mDir) $ do
         config <- loadConfig
-        runRestylers_ (cRestylers config) =<< getArgs
+        runRestylers_ config =<< getArgs
   where
     setupLog = setLogUseTime False . setLogUseLoc False
     setupApp logFunc mDir = App

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -56,6 +56,7 @@ import qualified Data.Yaml.Ext as Yaml
 import GitHub.Data (IssueLabel, User)
 import Restyler.App.Class
 import Restyler.Config.ExpectedKeys
+import Restyler.Config.Glob
 import Restyler.Config.RequestReview
 import Restyler.Config.Restyler
 import Restyler.Config.SketchyList
@@ -80,6 +81,7 @@ import Restyler.Restyler
 --
 data ConfigF f = ConfigF
     { cfEnabled :: f Bool
+    , cfExclude :: f (SketchyList Glob)
     , cfAuto :: f Bool
     , cfRemoteFiles :: f (SketchyList RemoteFile)
     , cfPullRequests :: f Bool
@@ -120,6 +122,7 @@ resolveConfig = bzipWith f
 --
 data Config = Config
     { cEnabled :: Bool
+    , cExclude :: [Glob]
     , cAuto :: Bool
     , cRemoteFiles :: [RemoteFile]
     , cPullRequests :: Bool
@@ -235,6 +238,7 @@ resolveRestylers ConfigF {..} allRestylers = do
 
     pure Config
         { cEnabled = runIdentity cfEnabled
+        , cExclude = unSketchy $ runIdentity cfExclude
         , cAuto = runIdentity cfAuto
         , cRemoteFiles = unSketchy $ runIdentity cfRemoteFiles
         , cPullRequests = runIdentity cfPullRequests

--- a/src/Restyler/Config/Glob.hs
+++ b/src/Restyler/Config/Glob.hs
@@ -1,0 +1,25 @@
+-- | Small wrapper over @'System.FilePath.Glob.Pattern'@
+module Restyler.Config.Glob
+    ( Glob
+    , match
+    )
+where
+
+import Restyler.Prelude
+
+import Data.Aeson
+import System.FilePath.Glob hiding (match)
+import qualified System.FilePath.Glob as Glob
+
+newtype Glob = Glob { unGlob :: Pattern }
+    deriving stock (Eq, Generic)
+    deriving newtype Show
+
+instance FromJSON Glob where
+    parseJSON = withText "Glob" $ pure . Glob . compile . unpack
+
+instance ToJSON Glob where
+    toJSON = String . pack . decompile . unGlob
+
+match :: Glob -> FilePath -> Bool
+match (Glob p) = Glob.match p

--- a/src/Restyler/Main.hs
+++ b/src/Restyler/Main.hs
@@ -85,10 +85,10 @@ restyle
        )
     => RIO env [RestylerResult]
 restyle = do
-    restylers <- cRestylers <$> view configL
+    config <- view configL
     pullRequest <- view pullRequestL
     pullRequestPaths <- changedPaths $ pullRequestBaseRef pullRequest
-    runRestylers restylers pullRequestPaths
+    runRestylers config pullRequestPaths
 
 wasRestyled :: (HasPullRequest env, HasGit env) => RIO env Bool
 wasRestyled = do

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -51,3 +51,7 @@ intersects a b = not $ Set.null $ Set.intersection a' b'
   where
     a' = Set.fromList $ F.toList a
     b' = Set.fromList $ F.toList b
+
+-- | Inverse of @'any'@
+none :: Foldable t => (a -> Bool) -> t a -> Bool
+none p = not . any p

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -14,6 +14,7 @@ import Restyler.Prelude
 import Data.List (nub)
 import Restyler.App.Class
 import Restyler.App.Error
+import Restyler.Config
 import Restyler.Config.Include
 import Restyler.Config.Interpreter
 import Restyler.Git
@@ -29,7 +30,7 @@ runRestylers
        , HasProcess env
        , HasGit env
        )
-    => [Restyler]
+    => Config
     -> [FilePath]
     -> RIO env [RestylerResult]
 runRestylers = runRestylersWith runRestyler
@@ -37,24 +38,24 @@ runRestylers = runRestylersWith runRestyler
 -- | Runs the given @'Restyler'@s but without committing or reporting results
 runRestylers_
     :: (HasLogFunc env, HasOptions env, HasSystem env, HasProcess env)
-    => [Restyler]
+    => Config
     -> [FilePath]
     -> RIO env ()
-runRestylers_ restylers = void . runRestylersWith runRestyler_ restylers
+runRestylers_ config = void . runRestylersWith runRestyler_ config
 
 runRestylersWith
     :: (HasSystem env, HasLogFunc env)
     => (Restyler -> [FilePath] -> RIO env b)
-    -> [Restyler]
+    -> Config
     -> [FilePath]
     -> RIO env [b]
-runRestylersWith run restylers allPaths = do
+runRestylersWith run Config {..} allPaths = do
     paths <- filterM doesFileExist allPaths
 
-    logDebug $ "Restylers: " <> displayShow (map rName restylers)
+    logDebug $ "Restylers: " <> displayShow (map rName cRestylers)
     logDebug $ "Paths: " <> displayShow paths
 
-    for restylers $ \r -> run r =<< filterRestylePaths r paths
+    for cRestylers $ \r -> run r =<< filterRestylePaths r paths
 
 filterRestylePaths
     :: HasSystem env => Restyler -> [FilePath] -> RIO env [FilePath]


### PR DESCRIPTION
We have trouble with projects that have committed dependency files that are
not actually part of their project. These files tend to be numerous and
exotic, which both slows us down and causes errors, for no benefit.

This patch implements a global exclude configuration and defaults it to the
handful of directories we see that cause this trouble.

NOTE: Restyler include happens after this and cannot pull files back in; 
it's as if they don't exist. Users for whom this doesn't work must disable
(set to empty) or adjust the exclude key itself.