### PR TITLE
Re-write restylers configuration handling

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -89,36 +89,6 @@ labels: []
 ignore_labels:
   - restyled-ignore
 
-# Which restylers to run
-#
-# See restyled-io/restylers repository for their defaults.
-#
-restylers:
-  - astyle
-  - autopep8
-  - black
-  # - brittany
-  - dfmt
-  - elm-format
-  # - google-java-format
-  # - hindent
-  # - hlint
-  # - jdt
-  - pg_format
-  - php-cs-fixer
-  - prettier
-  - prettier-markdown
-  - prettier-yaml
-  - prettier-ruby
-  - reorder-python-imports
-  - rubocop
-  - rustfmt
-  - shellharden
-  - shfmt
-  - stylish-haskell
-  - terraform
-  - yapf
-
 # Version of the set of Restylers to run
 #
 # This should correspond to a ref on the restyled-io/restylers repository,
@@ -126,4 +96,33 @@ restylers:
 # re-specify the default in your own config if you prefer to avoid update
 # surprises.
 #
-restylers_version: "20190910"
+restylers_version: "20191004"
+
+# Override Restylers behavior
+#
+# Example:
+#
+#   ---
+#   restylers:
+#     # disable a Restyler enabled by default
+#     prettier:
+#       enabled: false
+#
+#     # enable a Restyler disabled by default
+#     hlint:
+#       enabled: true
+#
+#     # adjust what files a Restyler runs on
+#     brittany:
+#       include:
+#         - "**/*.hs"
+#         - "!test/**/*"
+#
+#     # even use your own Restyler image (must be publicly pullable)
+#     stylish-haskell:
+#       image: pbrisbin/restyler-style-haskell:bugfix
+#
+# The empty object means to override nothing and accept the defaults defined in
+# the restyled-io/restylers repository for the configured restylers_version.
+#
+restylers: {}

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -65,9 +65,14 @@ statuses:
 #
 #   author: From the author of the original PR
 #   owner: From the owner of the repository
+#   none: Don't
 #
 # One value will apply to origin and forked PRs, but you can also specify
 # separate values.
+#
+#   request_review:
+#     origin: author
+#     forked: owner
 #
 request_review: none
 

--- a/restyle-path/main.hs
+++ b/restyle-path/main.hs
@@ -40,7 +40,7 @@ instance HasProcess App where
 
 instance HasDownloadFile App where
     downloadFile url path = liftIO $ do
-        request <- parseRequest $ unpack url
+        request <- parseRequestThrow $ unpack url
         runResourceT $ httpSink request $ \_ -> sinkFile path
 
 main :: IO ()

--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -101,7 +101,7 @@ instance HasDownloadFile StartupApp where
     downloadFile url path = do
         logDebug $ "HTTP GET: " <> displayShow url <> " => " <> displayShow path
         appIO HttpError $ do
-            request <- parseRequest $ unpack url
+            request <- parseRequestThrow $ unpack url
             runResourceT $ httpSink request $ \_ -> sinkFile path
 
 instance HasGitHub StartupApp where

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -8,8 +8,9 @@ where
 import RIO as X hiding (exitSuccess, first, second)
 
 import Control.Error.Util as X (hush, note)
-import Control.Monad.Extra as X (maybeM)
+import Control.Monad.Extra as X (eitherM, maybeM)
 import Data.Bifunctor as X (first, second)
+import Data.Bitraversable as X (Bitraversable, bimapM)
 import Data.Functor.Syntax as X ((<$$>))
 import GitHub.Data as X (Id, Name, URL(..), getUrl, mkId, mkName, untagName)
 import RIO.Char as X (isSpace)
@@ -20,6 +21,13 @@ import Safe as X (fromJustNote)
 import qualified Data.Foldable as F
 import qualified Data.Set as Set
 import qualified RIO.Text as T
+
+firstM :: (Bitraversable t, Applicative f) => (a -> f a') -> t a b -> f (t a' b)
+firstM f = bimapM f pure
+
+secondM
+    :: (Bitraversable t, Applicative f) => (b -> f b') -> t a b -> f (t a b')
+secondM = bimapM pure
 
 -- | Like @'withReader'@ for @'RIO'@
 withRIO :: (env' -> env) -> RIO env a -> RIO env' a

--- a/src/Restyler/Restyler.hs
+++ b/src/Restyler/Restyler.hs
@@ -16,7 +16,8 @@ import Restyler.Config.Interpreter
 import Restyler.RemoteFile
 
 data Restyler = Restyler
-    { rName :: String
+    { rEnabled :: Bool
+    , rName :: String
     , rImage :: String
     , rCommand :: [String]
     , rArguments :: [String]

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -53,11 +53,13 @@ runRestylersWith
 runRestylersWith run Config {..} allPaths = do
     paths <- filterM doesFileExist $ filter included allPaths
 
-    logDebug $ "Restylers: " <> displayShow (map rName cRestylers)
+    logDebug $ "Restylers: " <> displayShow (map rName restylers)
     logDebug $ "Paths: " <> displayShow paths
 
-    for cRestylers $ \r -> run r =<< filterRestylePaths r paths
-    where included path = none (`match` path) cExclude
+    for restylers $ \r -> run r =<< filterRestylePaths r paths
+  where
+    included path = none (`match` path) cExclude
+    restylers = filter rEnabled cRestylers
 
 filterRestylePaths
     :: HasSystem env => Restyler -> [FilePath] -> RIO env [FilePath]

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -17,116 +17,137 @@ import Restyler.Restyler
 
 spec :: Spec
 spec = do
-    it "supports a simple, name-based syntax" $ do
-        defaultConfig <- loadDefaultConfig
-
-        result <- loadTestConfig
-            $ C8.unlines ["---", "- stylish-haskell", "- prettier"]
-
-        result `shouldBe` Right defaultConfig
-            { cRestylers =
-                [ someRestyler { rName = "stylish-haskell" }
-                , someRestyler { rName = "prettier" }
-                ]
-            }
-
     it "has a setting for globally disabling" $ do
-        result <- loadTestConfig $ C8.unlines
-            ["---", "enabled: false", "restylers:", "- stylish-haskell"]
+        result <- loadTestConfig $ C8.unlines ["---", "enabled: false"]
 
         fmap cEnabled result `shouldBe` Right False
 
-    it "allows re-configuring includes" $ do
-        defaultConfig <- loadDefaultConfig
-
-        result1 <- loadTestConfig $ C8.unlines
-            ["---", "- stylish-haskell:", "    include:", "    - \"**/*.lhs\""]
-        result2 <- loadTestConfig $ C8.unlines
-            ["---", "- stylish-haskell:", "    include:", "    - \"**/*.lhs\""]
-        result3 <- loadTestConfig $ C8.unlines
-            [ "---"
-            , "restylers:"
-            , "- stylish-haskell:"
-            , "    include:"
-            , "    - \"**/*.lhs\""
-            ]
-
-        result1 `shouldBe` result2
-        result2 `shouldBe` result3
-        result3 `shouldBe` Right defaultConfig
-            { cRestylers =
-                [ someRestyler
-                      { rName = "stylish-haskell"
-                      , rInclude = [Include "**/*.lhs"]
-                      }
-                ]
-            }
-
-    it "has good errors for unknown name" $ do
-        result1 <- loadTestConfig $ C8.unlines ["---", "- uknown-name"]
-        result2 <- loadTestConfig $ C8.unlines
-            ["---", "- uknown-name:", "    arguments:", "    - --foo"]
-        result3 <- loadTestConfig $ C8.unlines
-            [ "---"
-            , "restylers:"
-            , "- uknown-name:"
-            , "    arguments:"
-            , "    - --foo"
-            ]
-
-        result1 `shouldSatisfy` hasError
-            "Unexpected Restyler name \"uknown-name\""
-        result2 `shouldSatisfy` hasError
-            "Unexpected Restyler name \"uknown-name\""
-        result3 `shouldSatisfy` hasError
-            "Unexpected Restyler name \"uknown-name\""
-
-    it "provides suggestions for close matches" $ do
-        result1 <- loadTestConfig $ C8.unlines ["---", "- hindex"]
-        result2 <- loadTestConfig
-            $ C8.unlines ["---", "- hindex:", "    arguments:", "    - --foo"]
-        result3 <- loadTestConfig $ C8.unlines
-            ["---", "restylers:", "- hindex:", "    arguments:", "    - --foo"]
-
-        result1 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
-        result2 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
-        result3 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
-
-    it "can specify a full Restyler" $ do
-        result <- loadTestConfig $ C8.unlines
-            [ "restylers:"
-            , "  - name: foo"
-            , "    image: restyled/restyler-foo"
-            , "    command: [foo]"
-            , "    arguments: []"
-            , "    include: []"
-            , "    interpreters: []"
-            , "    supports_arg_sep: false"
-            , "    supports_multiple_paths: false"
-            , "    documentation: []"
-            , "    include:"
-            , "      - \"**/*.js\""
-            , "      - \"**/*.jsx\""
-            ]
-
-        result `shouldSatisfy` isRight
-
-    it "handles invalid indentation nicely" $ do
-        result <- loadTestConfig $ C8.unlines
-            [ "restylers:"
-            , "  - prettier:"
-            , "    include:"
-            , "      - \"**/*.js\""
-            , "      - \"**/*.jsx\""
-            ]
-
-        result `shouldSatisfy` hasError "do you have incorrect indentation"
 
     it "handles tabs nicely" $ do
         result <- loadTestConfig
             $ C8.unlines ["statuses:", "\tdifferences: false"]
 
         result `shouldSatisfy` hasError "containing tabs"
+
+    it "allows re-configuring includes" $ do
+        defaultConfig <- loadDefaultConfig
+
+        result <- loadTestConfig $ C8.unlines
+            [ "---"
+            , "restylers:"
+            , "  stylish-haskell:"
+            , "    include:"
+            , "    - \"**/*.lhs\""
+            ]
+
+        result `shouldBe` Right defaultConfig
+            { cRestylers = testRestylersWith $ someRestyler
+                { rName = "stylish-haskell"
+                , rInclude = [Include "**/*.lhs"]
+                }
+            }
+
+    it "has good errors for unknown name" $ do
+        result <- loadTestConfig $ C8.unlines
+            [ "---"
+            , "restylers:"
+            , "  uknown-name:"
+            , "    arguments:"
+            , "    - --foo"
+            ]
+
+        result `shouldSatisfy` hasError
+            "Unexpected Restyler name \"uknown-name\""
+
+    it "provides suggestions for close matches" $ do
+        result <- loadTestConfig $ C8.unlines
+            ["---", "restylers:", "  hindex:", "    arguments:", "    - --foo"]
+
+        result `shouldSatisfy` hasError ", did you mean \"hindent\"?"
+
+    context "legacy list-style format" $ do
+        it "supports a simple, name-based syntax" $ do
+            defaultConfig <- loadDefaultConfig
+
+            result <- loadTestConfig $ C8.unlines ["---", "- hindent"]
+
+            result `shouldBe` Right defaultConfig
+                { cRestylers = testRestylersWith
+                    $ someRestyler { rName = "hindent", rEnabled = True }
+                }
+
+        it "allows re-configuring includes" $ do
+            defaultConfig <- loadDefaultConfig
+
+            result1 <-
+                loadTestConfig
+                    $ C8.unlines
+                          [ "---"
+                          , "- stylish-haskell:"
+                          , "    include:"
+                          , "    - \"**/*.lhs\""
+                          ]
+            result2 <-
+                loadTestConfig
+                    $ C8.unlines
+                          [ "---"
+                          , "- stylish-haskell:"
+                          , "    include:"
+                          , "    - \"**/*.lhs\""
+                          ]
+            result3 <- loadTestConfig $ C8.unlines
+                [ "---"
+                , "restylers:"
+                , "- stylish-haskell:"
+                , "    include:"
+                , "    - \"**/*.lhs\""
+                ]
+
+            result1 `shouldBe` result2
+            result2 `shouldBe` result3
+            result3 `shouldBe` Right defaultConfig
+                { cRestylers = testRestylersWith $ someRestyler
+                    { rName = "stylish-haskell"
+                    , rInclude = [Include "**/*.lhs"]
+                    }
+                }
+
+        it "has good errors for unknown name" $ do
+            result1 <- loadTestConfig $ C8.unlines ["---", "- uknown-name"]
+            result2 <- loadTestConfig $ C8.unlines
+                ["---", "- uknown-name:", "    arguments:", "    - --foo"]
+            result3 <- loadTestConfig $ C8.unlines
+                [ "---"
+                , "restylers:"
+                , "- uknown-name:"
+                , "    arguments:"
+                , "    - --foo"
+                ]
+
+            result1 `shouldSatisfy` hasError
+                "Unexpected Restyler name \"uknown-name\""
+            result2 `shouldSatisfy` hasError
+                "Unexpected Restyler name \"uknown-name\""
+            result3 `shouldSatisfy` hasError
+                "Unexpected Restyler name \"uknown-name\""
+
+        it "provides suggestions for close matches" $ do
+            result1 <- loadTestConfig $ C8.unlines ["---", "- hindex"]
+            result2 <- loadTestConfig $ C8.unlines
+                ["---", "- hindex:", "    arguments:", "    - --foo"]
+            result3 <-
+                loadTestConfig
+                    $ C8.unlines
+                          [ "---"
+                          , "restylers:"
+                          , "- hindex:"
+                          , "    arguments:"
+                          , "    - --foo"
+                          ]
+
+            result1 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
+            result2 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
+            result3 `shouldSatisfy` hasError ", did you mean \"hindent\"?"
 
 hasError :: String -> Either String a -> Bool
 hasError msg (Left err) = msg `isInfixOf` err
@@ -150,8 +171,8 @@ loadTestConfig content =
 showConfigError :: ConfigError -> String
 showConfigError = \case
     ConfigErrorInvalidYaml _ ex -> prettyPrintParseException ex
-    ConfigErrorInvalidRestylers es -> unlines es
-    ConfigErrorNoRestylers -> "No restylers"
+    ConfigErrorUnknownRestylers err -> err
+    ConfigErrorInvalidRestylersYaml ex -> show ex
 
 testRestylers :: [Restyler]
 testRestylers =
@@ -160,8 +181,8 @@ testRestylers =
     , someRestyler { rName = "black" }
     , someRestyler { rName = "dfmt" }
     , someRestyler { rName = "elm-format" }
-    , someRestyler { rName = "hindent" }
-    , someRestyler { rName = "jdt" }
+    , someRestyler { rName = "hindent", rEnabled = False }
+    , someRestyler { rName = "jdt", rEnabled = False }
     , someRestyler { rName = "pg_format" }
     , someRestyler { rName = "php-cs-fixer" }
     , someRestyler { rName = "prettier" }
@@ -177,3 +198,11 @@ testRestylers =
     , someRestyler { rName = "terraform" }
     , someRestyler { rName = "yapf" }
     ]
+
+testRestylersWith :: Restyler -> [Restyler]
+testRestylersWith restyler = map (replaceByName restyler) testRestylers
+
+replaceByName :: Restyler -> Restyler -> Restyler
+replaceByName a b
+    | rName a == rName b = a
+    | otherwise = b

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -86,7 +86,8 @@ instance HasProcess TestApp where
 
 someRestyler :: Restyler
 someRestyler = Restyler
-    { rName = "test-restyler"
+    { rEnabled = True
+    , rName = "test-restyler"
     , rImage = "restyled/restyler-test-restyler"
     , rCommand = ["restyle"]
     , rDocumentation = []


### PR DESCRIPTION
- Expect an enabled key in the `restylers.yaml`

  This means which Restylers are run by default is set there.

- Local restylers key is purely overrides

  Therefore,

  - `enabled:false` to disable if enabled by default
  - `enabled:true` to enable if disabled by default

We make a best-effort to support configurations in the wild, but we don't go for
total compatibility:

  - If someone names a `restylers_version` that lacks the recent enabled keys,
    that's an error (but it is informative)

  - If someone uses the list-style configuration:

    - Missing restylers, if enabled by default, will now run
    - Specifying a full Restyler object is no longer supported (but this error
      is also informative), I don't think anyone used that