### PR TITLE
Support lifting Restyler container restrictions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
 
   image:
     docker:
-      - image: restyled/ops:v7
+      - image: restyled/ops:v8
     steps:
       - checkout
       - setup_remote_docker:
@@ -70,7 +70,7 @@ jobs:
 
   release:
     docker:
-      - image: restyled/ops:v7
+      - image: restyled/ops:v8
     steps:
       - run:
           name: Release

--- a/bin/restyle-path
+++ b/bin/restyle-path
@@ -28,6 +28,7 @@
 exec docker run -it --rm \
   --env DEBUG=1 \
   --env HOST_DIRECTORY="$PWD" \
+  --env UNRESTRICTED=1 \
   --volume "$PWD":/code \
   --volume /tmp:/tmp \
   --volume /var/run/docker.sock:/var/run/docker.sock \

--- a/package.yaml
+++ b/package.yaml
@@ -113,6 +113,7 @@ executables:
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:
+      - envparse
       - conduit
       - http-conduit
       - text

--- a/restyle-path/main.hs
+++ b/restyle-path/main.hs
@@ -47,6 +47,7 @@ instance HasDownloadFile App where
 data EnvOptions = EnvOptions
     { eoHostDirectory :: Maybe FilePath
     , eoVerbose :: Bool
+    , eoUnrestricted :: Bool
     }
 
 -- brittany-disable-next-binding
@@ -54,6 +55,7 @@ envParser :: Env.Parser Env.Error EnvOptions
 envParser = EnvOptions
     <$> optional (Env.var Env.str "HOST_DIRECTORY" Env.keep)
     <*> Env.switch "DEBUG" Env.keep
+    <*> Env.switch "UNRESTRICTED" Env.keep
 
 main :: IO ()
 main = do
@@ -75,5 +77,6 @@ main = do
             , oPullRequest = error "unused"
             , oJobUrl = error "unused"
             , oHostDirectory = eoHostDirectory
+            , oUnrestricted = eoUnrestricted
             }
         }

--- a/src/Restyler/Options.hs
+++ b/src/Restyler/Options.hs
@@ -24,6 +24,7 @@ data ColorOption
 data EnvOptions = EnvOptions
     { eoAccessToken :: Text
     , eoLogLevel :: LogLevel
+    , eoUnrestricted :: Bool
     }
 
 data CLIOptions = CLIOptions
@@ -43,6 +44,7 @@ data Options = Options
     , oPullRequest :: IssueNumber
     , oJobUrl :: Maybe URL
     , oHostDirectory :: Maybe FilePath
+    , oUnrestricted :: Bool
     }
 
 class HasOptions env where
@@ -73,6 +75,7 @@ parseOptions = do
         , oPullRequest = prsPullRequest coPullRequestSpec
         , oJobUrl = coJobUrl
         , oHostDirectory = coHostDirectory
+        , oUnrestricted = eoUnrestricted
         }
 
 -- brittany-disable-next-binding
@@ -81,6 +84,7 @@ envParser = EnvOptions
     <$> Env.var (Env.str <=< Env.nonempty) "GITHUB_ACCESS_TOKEN"
         (Env.help "GitHub access token with write access to the repository")
     <*> Env.flag LevelInfo LevelDebug "DEBUG" Env.keep
+    <*> Env.switch "UNRESTRICTED" Env.keep
 
 -- brittany-disable-next-binding
 optionsParser :: Parser CLIOptions

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -121,7 +121,7 @@ dockerRunRestyler r@Restyler {..} paths = do
     unrestricted <- oUnrestricted <$> view optionsL
     ec <-
         callProcessExitCode "docker"
-        $ ["run", "--rm"]
+        $ ["run", "--rm", "--net", "none"]
         <> bool restrictions [] unrestricted
         <> ["--volume", cwd <> ":/code", rImage]
         <> nub (rCommand <> rArguments)
@@ -136,8 +136,7 @@ dockerRunRestyler r@Restyler {..} paths = do
 
 restrictions :: [String]
 restrictions =
-    [ "--net", "none"
-    , "--cap-drop", "all"
+    [ "--cap-drop", "all"
     , "--cpu-shares", "128"
     , "--memory", "512m"
     ]

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -132,14 +132,8 @@ dockerRunRestyler r@Restyler {..} paths = do
         ExitSuccess -> pure ()
         ExitFailure s -> throwIO $ RestylerExitFailure r s paths
 
--- brittany-disable-next-bindings
-
 restrictions :: [String]
-restrictions =
-    [ "--cap-drop", "all"
-    , "--cpu-shares", "128"
-    , "--memory", "512m"
-    ]
+restrictions = ["--cap-drop", "all", "--cpu-shares", "128", "--memory", "512m"]
 
 getHostDirectory :: (HasOptions env, HasSystem env) => RIO env FilePath
 getHostDirectory = do

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -118,10 +118,11 @@ dockerRunRestyler
     -> RIO env ()
 dockerRunRestyler r@Restyler {..} paths = do
     cwd <- getHostDirectory
+    unrestricted <- oUnrestricted <$> view optionsL
     ec <-
         callProcessExitCode "docker"
         $ ["run", "--rm"]
-        <> restrictions
+        <> bool restrictions [] unrestricted
         <> ["--volume", cwd <> ":/code", rImage]
         <> nub (rCommand <> rArguments)
         <> [ "--" | rSupportsArgSep ]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -64,6 +64,7 @@ testOptions = Options
     , oPullRequest = error "oPullRequest"
     , oJobUrl = error "oJobUrl"
     , oHostDirectory = Nothing
+    , oUnrestricted = False
     }
 
 instance HasLogFunc TestApp where


### PR DESCRIPTION
Set `UNRESTRICTED=1` to remove all container restrictions on the Restylers, e.g.
net-none, cap-drop-all, cpu-shares, and memory.

This is specifically to avoid having cap-drop-all when run locally via
restyle-path, because that causes the root-run Restylers to not have access to
user-owned local files (they're root-owned on production, so it all still works
there). We could introduce a variable to specifically affect cap-drop, but this
bigger, simpler hammer seems fine enough.