### PR TITLE
Clarify Restyler configuration defaulting

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -147,6 +147,11 @@ restylers_version: "20200209"
 #       arguments: ["--another"]
 #       include: ["needs-another/**/*.js"]
 #
+# Omitted keys inherit defaults for the Restyler of that name, which can be seen
+# in the wiki:
+#
+#   https://github.com/restyled-io/restyled.io/wiki/Available-Restylers
+#
 # Valid keys in the override object are:
 #
 # - enabled: true|false


### PR DESCRIPTION
I made quite a smaller change in this version, but I think in context it
clarifies what was missing before:

```
# Restylers can be specified in three ways:
#
# A string, which means to run that Restyler with all defaults
#
#   [...]
#
# A single key, that is a name, and override value:
#
#   [...]
#
# An object with a name key
#
#   [...]
#
# All three of the above are equivalent. The latter two are useful if you want
# to run the same Restyler multiple ways:
#
#   [...]
#
# Omitted keys inherit defaults for the Restyler of that name, which can be seen
# in the wiki:
#
#   https://github.com/restyled-io/restyled.io/wiki/Available-Restylers
#
# Valid keys in the override object are:
```

I think the initial phrase "with all defaults" indicates how it works, calling
it an "override" also re-enforces it. The newly added bit calls it out
explicitly, and linking to the defaults instead of in-lining examples will keep
down the maintenance burden.

/cc @drmingdrmer