### PR TITLE
Find existing Restyle PRs even if Closed

### DIFF
--- a/src/Restyler/Main.hs
+++ b/src/Restyler/Main.hs
@@ -62,15 +62,7 @@ restylerMain = do
         sendPullRequestStatus $ DifferencesStatus jobUrl
         exitWithInfo "Not creating (or updating) Restyle PR, disabled by config"
 
-    mRestyledPullRequest <- view restyledPullRequestL
-    restyledUrl <- case mRestyledPullRequest of
-        Just restyledPr -> do
-            updateRestyledPullRequest
-            pure $ simplePullRequestHtmlUrl restyledPr
-        Nothing -> do
-            restyledPr <- createRestyledPullRequest results
-            pure $ pullRequestHtmlUrl restyledPr
-
+    restyledUrl <- createOrUpdateRestyledPullRequest results
     sendPullRequestStatus $ DifferencesStatus $ Just restyledUrl
     exitWithInfo "Restyling successful"
 

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -8,7 +8,7 @@ where
 import RIO as X hiding (exitSuccess, first, second)
 
 import Control.Error.Util as X (hush, note)
-import Control.Monad.Extra as X (eitherM, maybeM)
+import Control.Monad.Extra as X (eitherM, fromMaybeM, maybeM)
 import Data.Bifunctor as X (first, second)
 import Data.Bitraversable as X (Bitraversable, bimapM)
 import Data.Functor.Syntax as X ((<$$>))
@@ -68,3 +68,6 @@ none p = not . any p
 
 insertIfMissing :: (Eq k, Hashable k) => k -> v -> HashMap k v -> HashMap k v
 insertIfMissing = HM.insertWith $ flip const
+
+with :: (Traversable t, Applicative f) => t a -> (a -> f b) -> f (t a)
+with ma f = for ma $ \a -> a <$ f a

--- a/src/Restyler/PullRequest.hs
+++ b/src/Restyler/PullRequest.hs
@@ -124,6 +124,7 @@ pullRequestRestyledMod :: PullRequest -> PullRequestMod
 pullRequestRestyledMod pullRequest = mconcat
     [ optionsBase $ pullRequestRestyledBase pullRequest
     , optionsHead $ pullRequestRestyledRefQualified pullRequest
+    , stateAll
     ]
 
 --------------------------------------------------------------------------------

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -2,7 +2,6 @@ module Restyler.PullRequest.Restyled
     ( createOrUpdateRestyledPullRequest
     , closeRestyledPullRequest
     , closeRestyledPullRequest'
-    , updateOriginalPullRequest
     )
 where
 
@@ -188,8 +187,3 @@ editRestyledPullRequest pullRequest restyledPr =
         (pullRequestOwnerName pullRequest)
         (pullRequestRepoName pullRequest)
         (simplePullRequestNumber restyledPr)
-
--- | Commit and push to current branch
-updateOriginalPullRequest :: (HasPullRequest env, HasGit env) => RIO env ()
-updateOriginalPullRequest =
-    gitPush . unpack . pullRequestHeadRef =<< view pullRequestL

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -110,6 +110,21 @@ updateRestyledPullRequest = do
 
     with mRestyledPr $ \restyledPr -> do
         logInfo "Updating existing Restyle PR"
+
+        when (simplePullRequestState restyledPr == StateClosed) $ do
+            logInfo "Restyle PR was closed, re-opening"
+            editRestyledPullRequest
+                pullRequest
+                restyledPr
+                EditPullRequest
+                    { editPullRequestTitle = Nothing
+                    , editPullRequestBody = Nothing
+                    , editPullRequestState = Just StateOpen
+                    , editPullRequestBase = Nothing
+                    , editPullRequestMaintainerCanModify = Nothing
+                    }
+
+        logInfo "Pushing to Restyle commits to existing branch"
         gitPushForce $ unpack $ pullRequestRestyledRef pullRequest
 
 -- | Close the Restyled PR, if we know of it

--- a/src/Restyler/PullRequest/Restyled.hs
+++ b/src/Restyler/PullRequest/Restyled.hs
@@ -144,10 +144,9 @@ closeRestyledPullRequest' pullRequest mRestyledPr =
                 }
 
         logInfo $ "Closing restyled PR: " <> displayShow spec
-        runGitHub_ $ updatePullRequestR
-            (pullRequestOwnerName pullRequest)
-            (pullRequestRepoName pullRequest)
-            (simplePullRequestNumber restyledPr)
+        editRestyledPullRequest
+            pullRequest
+            restyledPr
             EditPullRequest
                 { editPullRequestTitle = Nothing
                 , editPullRequestBody = Nothing
@@ -162,6 +161,18 @@ closeRestyledPullRequest' pullRequest mRestyledPr =
             (pullRequestOwnerName pullRequest)
             (pullRequestRepoName pullRequest)
             (mkName Proxy $ "heads/" <> branch)
+
+editRestyledPullRequest
+    :: HasGitHub env
+    => PullRequest
+    -> SimplePullRequest
+    -> EditPullRequest
+    -> RIO env ()
+editRestyledPullRequest pullRequest restyledPr =
+    runGitHub_ . updatePullRequestR
+        (pullRequestOwnerName pullRequest)
+        (pullRequestRepoName pullRequest)
+        (simplePullRequestNumber restyledPr)
 
 -- | Commit and push to current branch
 updateOriginalPullRequest :: (HasPullRequest env, HasGit env) => RIO env ()


### PR DESCRIPTION
Our update routine is now capable of dealing with this by re-opening them. This
avoids creating a new Restyle PR when formatting is fixed and re-broken during a
single PR's evolution.

Fixes restyled-io/restyled.io#191