### PR TITLE
Configurability of Restyled branch_name

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -10,7 +10,6 @@
 
 # N.B. must be kept in sync with package.yaml
 - arguments:
-  - -XAutoDeriveTypeable
   - -XBangPatterns
   - -XBinaryLiterals
   - -XConstraintKinds
@@ -32,7 +31,6 @@
   - -XGeneralizedNewtypeDeriving
   - -XInstanceSigs
   - -XKindSignatures
-  - -XMonadFailDesugaring
   - -XMultiParamTypeClasses
   - -XMultiWayIf
   - -XNamedFieldPuns

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,4 +1,8 @@
 ---
+
+# N.B. beta-testing with alternative default
+branch_name: "restyled/{base}"
+
 restylers:
   - stylish-haskell
   - brittany

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -23,7 +23,6 @@ newline: native
 
 # N.B. must be kept in sync with package.yaml
 language_extensions:
-  - AutoDeriveTypeable
   - BangPatterns
   - BinaryLiterals
   - ConstraintKinds
@@ -45,7 +44,6 @@ language_extensions:
   - GeneralizedNewtypeDeriving
   - InstanceSigs
   - KindSignatures
-  - MonadFailDesugaring
   - MultiParamTypeClasses
   - MultiWayIf
   - NamedFieldPuns

--- a/brittany.yaml
+++ b/brittany.yaml
@@ -23,7 +23,6 @@ conf_preprocessor:
 # N.B. must be kept in sync with package.yaml
 conf_forward:
   options_ghc:
-    - -XAutoDeriveTypeable
     - -XBangPatterns
     - -XBinaryLiterals
     - -XConstraintKinds
@@ -45,7 +44,6 @@ conf_forward:
     - -XGeneralizedNewtypeDeriving
     - -XInstanceSigs
     - -XKindSignatures
-    - -XMonadFailDesugaring
     - -XMultiParamTypeClasses
     - -XMultiWayIf
     - -XNamedFieldPuns

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -45,6 +45,12 @@ remote_files: []
 # Open Restyle PRs?
 pull_requests: true
 
+# How to name the Restyle PRs branch
+#
+# The value {base} will be interpolated with the original PR's branch.
+#
+branch_name: "{base}-restyled"
+
 # Leave comments on the original PR linking to the Restyle PR?
 comments: false
 

--- a/src/Restyler/Config/BranchName.hs
+++ b/src/Restyler/Config/BranchName.hs
@@ -1,0 +1,42 @@
+module Restyler.Config.BranchName
+    ( BranchName
+    , interpolateBranchName
+    )
+where
+
+import Restyler.Prelude
+
+import Data.Aeson
+import qualified Data.Text as T
+
+newtype BranchName = BranchName
+    { interpolateBranchName :: Text -> Text
+    }
+
+branchName :: Text -> BranchName
+branchName x = BranchName $ \base -> T.replace interpolation base x
+
+asInterpolation :: BranchName -> Text
+asInterpolation b = interpolateBranchName b interpolation
+
+instance Eq BranchName where
+    (==) = (==) `on` asInterpolation
+
+instance Show BranchName where
+    show = show . asInterpolation
+
+instance FromJSON BranchName where
+    parseJSON = withText "BranchName" $ \input -> do
+        unless (interpolation `T.isInfixOf` input)
+            $ fail
+            $ "A BranchName should contain the interpolation "
+            <> unpack interpolation
+            <> " somewhere. Otherwise, every Restyle PR would get the same branch"
+            <> " name, which will likely cause problems."
+        pure $ branchName input
+
+instance ToJSON BranchName where
+    toJSON = String . asInterpolation
+
+interpolation :: Text
+interpolation = "{base}"

--- a/src/Restyler/Main.hs
+++ b/src/Restyler/Main.hs
@@ -48,7 +48,8 @@ restylerMain = do
         logInfo "Pushing Restyle commits to original PR"
         pullRequest <- view pullRequestL
         gitCheckoutExisting $ unpack $ pullRequestLocalHeadRef pullRequest
-        gitMerge $ unpack $ pullRequestRestyledRef pullRequest
+        restyledRef <- view $ configL . to (configRestyledRef pullRequest)
+        gitMerge $ unpack restyledRef
 
         -- This will fail if other changes came in while we were restyling, but
         -- it also means that we should be working on a Job for those changes

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -55,6 +55,9 @@ handleTo f = handle (throwIO . f)
 tryTo :: (MonadUnliftIO m, Exception e) => (e -> b) -> m a -> m (Either b a)
 tryTo f = fmap (first f) . try
 
+tryToM :: (MonadUnliftIO m, Exception e) => (e -> m b) -> m a -> m (Either b a)
+tryToM f = firstM f <=< try
+
 intersects :: (Foldable t1, Foldable t2, Ord a) => t1 a -> t2 a -> Bool
 intersects a b = not $ Set.null $ Set.intersection a' b'
   where

--- a/src/Restyler/PullRequest.hs
+++ b/src/Restyler/PullRequest.hs
@@ -23,7 +23,6 @@ module Restyler.PullRequest
     , pullRequestRemoteHeadRef
     , pullRequestLocalHeadRef
     , pullRequestRestyledBase
-    , pullRequestRestyledRef
     , pullRequestRestyledMod
     )
 where
@@ -117,13 +116,10 @@ pullRequestRestyledBase pullRequest
     | pullRequestIsFork pullRequest = pullRequestBaseRef pullRequest
     | otherwise = pullRequestHeadRef pullRequest
 
-pullRequestRestyledRef :: PullRequest -> Text
-pullRequestRestyledRef = (<> "-restyled") . pullRequestLocalHeadRef
-
-pullRequestRestyledMod :: PullRequest -> PullRequestMod
-pullRequestRestyledMod pullRequest = mconcat
+pullRequestRestyledMod :: PullRequest -> Text -> PullRequestMod
+pullRequestRestyledMod pullRequest restyledRef = mconcat
     [ optionsBase $ pullRequestRestyledBase pullRequest
-    , optionsHead $ pullRequestRestyledRefQualified pullRequest
+    , optionsHead $ qualifyRef pullRequest restyledRef
     ]
 
 --------------------------------------------------------------------------------
@@ -133,11 +129,11 @@ pullRequestRestyledMod pullRequest = mconcat
 pullRequestOwner :: HasCallStack => PullRequest -> SimpleOwner
 pullRequestOwner = repoOwner . pullRequestRepo
 
-pullRequestRestyledRefQualified :: HasCallStack => PullRequest -> Text
-pullRequestRestyledRefQualified pullRequest =
+qualifyRef :: HasCallStack => PullRequest -> Text -> Text
+qualifyRef pullRequest ref =
     toPathPart (pullRequestOwnerName pullRequest)
         <> ":"
-        <> pullRequestRestyledRef pullRequest
+        <> ref
 
 -- |
 --


### PR DESCRIPTION
Closes #85.

The hard-coded pattern of `{base}-restyled` for Restyled Ref names doesn't always
work, especially when other bots' PRs expect names like `{namespace}/*` to be
branches they can freely edit: a branch named `other-bot/foo-restyled` can cause
problems.

Therefore, we want to give flexibility to users to work around this via 
their configuration:

```yaml
branch_name: "restyled/{base}"
```

Would result in `restyled/other-bot/foo,` which will not be problematic to the
bot that thinks `other-bot/`-prefixed branches are their own.

The most major change here was dealing with the case where:

1. The Restyle PR was opened
1. The user ignored it
1. The original PR is closed
1. Restyler fails fetching or checking out the head branch

This is not an edge case since closing a PR can very often mean deleting its
head branch immediately (GitHub can now helpfully automate this), which will
cause such a failure on Restyle.

In such a case, we're obviously unable to load the head branch's configuration,
but that now means we can't find the `branch_name,` which means we can't find
the Restyled PR, which prevents cleaning up the PR we created at (1).

The approach in this commit is to fall back to the default branch's
configuration when we can (i.e. when the clone succeeds, but fetches or
checkouts fail). As long as it's using the same `branch_name` as the just-closed
PR, things will work the same way. If it's not, we will skip the clean up, or
--absolute worst-case-- we would clean up a different PR. That final bit seems
bad, but the actual negative outcome of such a misfire should be minimal and
(hopefully) it rarely happens, so we accept it as an un-handled edge-case.