### PR TITLE
Deprecate restylers key, add overrides key

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -29,4 +29,7 @@ ignore_labels:
 
 restylers_version: "20200428"
 
+# Deprecated, use overrides instead
 restylers: null
+
+overrides: null

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -265,10 +265,10 @@ handleRestylers Nothing Nothing restylers = pure restylers
 handleRestylers Nothing (Just overrides) restylers =
     pure $ overrideRestylers restylers overrides
 handleRestylers (Just _) (Just overrides) restylers = do
-    restylersDeprecation "ignoring (using overrides instead)"
+    restylersDeprecation "discarding (using overrides instead)"
     pure $ overrideRestylers restylers overrides
 handleRestylers (Just overrides) Nothing restylers = do
-    restylersDeprecation "please use overrides instead"
+    restylersDeprecation "please configure overrides instead"
     eitherM (throwIO . ConfigErrorUnknownRestylers) pure
         $ pure
         $ legacyOverrideRestylers restylers overrides
@@ -276,7 +276,7 @@ handleRestylers (Just overrides) Nothing restylers = do
 restylersDeprecation :: HasLogFunc env => Utf8Builder -> RIO env ()
 restylersDeprecation msg =
     logWarn
-        $ "Deprecated restylers key found, "
+        $ "Deprecated restylers configuration in use, "
         <> msg
         <> ". See https://github.com/restyled-io/restyled.io/wiki/Configuring-Restyled"
         <> " for more details."

--- a/src/Restyler/Config/Glob.hs
+++ b/src/Restyler/Config/Glob.hs
@@ -1,6 +1,7 @@
 -- | Small wrapper over @'System.FilePath.Glob.Pattern'@
 module Restyler.Config.Glob
     ( Glob
+    , glob
     , match
     )
 where
@@ -8,18 +9,21 @@ where
 import Restyler.Prelude
 
 import Data.Aeson
-import System.FilePath.Glob hiding (match)
+import System.FilePath.Glob hiding (glob, match)
 import qualified System.FilePath.Glob as Glob
 
 newtype Glob = Glob { unGlob :: Pattern }
     deriving stock (Eq, Generic)
     deriving newtype Show
 
+glob :: String -> Glob
+glob = Glob . compile
+
 instance FromJSON Glob where
-    parseJSON = withText "Glob" $ pure . Glob . compile . unpack
+    parseJSON = withText "Glob" $ pure . glob . unpack
 
 instance ToJSON Glob where
     toJSON = String . pack . decompile . unGlob
 
-match :: Glob -> FilePath -> Bool
+match :: Glob -> String -> Bool
 match (Glob p) = Glob.match p

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -8,7 +8,7 @@ where
 import SpecHelper
 
 import qualified Data.ByteString.Char8 as C8
-import Data.List (isInfixOf)
+import Data.List (isInfixOf, partition)
 import Data.Yaml (decodeThrow, prettyPrintParseException)
 import Restyler.Config
 import Restyler.Config.Include
@@ -132,6 +132,38 @@ spec = do
                 ]
             }
 
+    context "overrides" $ do
+        it "can override one Restyler without disabling others" $ example $ do
+            result <- assertTestConfig $ C8.unlines
+                ["overrides:", "  - name: astyle", "    enabled: false"]
+
+            let restylers = cRestylers result
+                astyle = find ((== "astyle") . rName) restylers
+            fmap rEnabled astyle `shouldBe` Just False
+            map rName restylers `shouldBe` map rName testRestylers
+
+        it "can override with a pattern" $ example $ do
+            result <- assertTestConfig $ C8.unlines
+                ["overrides:", "  - name: \"*\"", "    enabled: false"]
+
+            cRestylers result `shouldSatisfy` none rEnabled
+
+        it "applies first override to match" $ example $ do
+            result <-
+                assertTestConfig
+                    $ C8.unlines
+                          [ "overrides:"
+                          , "  - astyle"
+                          , "  - \"*\":"
+                          , "      enabled: false"
+                          ]
+
+            let
+                (astyles, nonAstyles) =
+                    partition ((== "astyle") . rName) $ cRestylers result
+            map rEnabled astyles `shouldBe` [True]
+            nonAstyles `shouldSatisfy` none rEnabled
+
     it "handles invalid indentation nicely" $ example $ do
         result <- loadTestConfig $ C8.unlines
             [ "restylers:"
@@ -170,6 +202,10 @@ loadTestConfig content = do
         $ loadConfigFrom (ConfigContent content)
         $ const
         $ pure testRestylers
+
+-- | Load a @'ByteString'@ as configuration, fail on errors
+assertTestConfig :: MonadIO m => ByteString -> m Config
+assertTestConfig = either throwString pure <=< loadTestConfig
 
 showConfigError :: ConfigError -> String
 showConfigError = \case


### PR DESCRIPTION
The current restylers key has the annoying behavior that if you use it to modify
one Restyler, you no longer run any of the other default Restylers (unless you
also add them explicitly).

Changing this would impact current users too drastically, so this commit adds a
new key which is basically the same, except corrects this behavior.

The naming is somewhat important: `restylers` as a name does signal that you're
defining the list of Restylers to run, full stop. While `overrides` indicates
you just want to override some thing(s) and not lose others.

We deprecate the restylers key as part of this, which means that users who
indeed wish to configure only a specific set of Restylers to run must be able to
do so, even as Restylers are added to the system defaults later, without having
to update their configs in response.

To support this, we accept the override `name` key as a Glob. This means that
such users would use the following configuration:

```yaml
overrides:
  - one
  - two
  - "*":
      enabled: false
```

The initial items declare what to run, and the final wildcard ensures no other
(not yet known) Restylers are ever run. The single wildcard will be the most
common usage, but it is a glob, so configuring (e.g.) `prettier*` at once, say
to use a newer image, is also supported.

The behavior of interpreting a top-level list as the `restylers` key remains for
now. When we fully remove the `restylers` key we will also remove this behavior
and force everyone to always configure an object at top-level, and so choose the
`overrides` key. Maybe we'll bring back the list convenience as a short-cut for
overrides after that.

Closes restyled-io/restyled.io#197.