### PR TITLE
Support wildcards in restylers key

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -30,4 +30,5 @@ ignore_labels:
 
 restylers_version: "20200428"
 
-restylers: null
+restylers:
+  - "*"

--- a/src/Restyler/App/Error.hs
+++ b/src/Restyler/App/Error.hs
@@ -81,7 +81,7 @@ toErrorBody = reflow . \case
         , "Original input:"
         , unpack $ decodeUtf8 yaml
         ]
-    ConfigurationError (ConfigErrorUnknownRestylers errs) -> unlines errs
+    ConfigurationError (ConfigErrorInvalidRestylers errs) -> unlines errs
     ConfigurationError (ConfigErrorInvalidRestylersYaml e) -> unlines
         [ "Error loading restylers.yaml definition:"
         , show e
@@ -183,7 +183,7 @@ dieAppError e = do
     hPutStrLn stderr $ prettyAppError e
     exitWith $ ExitFailure $ case e of
         ConfigurationError ConfigErrorInvalidYaml{} -> 10
-        ConfigurationError ConfigErrorUnknownRestylers{} -> 11
+        ConfigurationError ConfigErrorInvalidRestylers{} -> 11
         ConfigurationError ConfigErrorInvalidRestylersYaml{} -> 12
         RestylerExitFailure{} -> 20
         GitHubError{} -> 30

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -235,8 +235,7 @@ decodeThrow' content =
 resolveRestylers :: ConfigF Identity -> [Restyler] -> RIO env Config
 resolveRestylers ConfigF {..} allRestylers = do
     restylers <-
-        eitherM (throwIO . ConfigErrorInvalidRestylers) pure
-        $ pure
+        either (throwIO . ConfigErrorInvalidRestylers) pure
         $ overrideRestylers allRestylers
         $ unSketchy
         $ runIdentity cfRestylers

--- a/src/Restyler/Config/Restyler.hs
+++ b/src/Restyler/Config/Restyler.hs
@@ -46,15 +46,9 @@ suffixIncorrectIndentation = modifyFailure (<> msg)
     where msg = "\n\nDo you have incorrect indentation for a named override?"
 
 overrideRestylers
-    :: [Restyler] -> Maybe [RestylerOverride] -> Either [String] [Restyler]
-overrideRestylers restylers =
-    maybe (pure restylers) (toEither . overrideRestylers' restylers)
-
--- | @'overrideRestylers'@ in @'Validation'@
-overrideRestylers'
-    :: [Restyler] -> [RestylerOverride] -> Validation [String] [Restyler]
-overrideRestylers' restylers overrides =
-    case length $ filter ((== "*") . roName) overrides of
+    :: [Restyler] -> [RestylerOverride] -> Either [String] [Restyler]
+overrideRestylers restylers overrides =
+    toEither $ case length $ filter ((== "*") . roName) overrides of
         0 -> explicits <$> getOverrides
         1 -> replaced restylers <$> getOverrides
         _ -> Failure ["TODO"]

--- a/src/Restyler/Config/Restyler.hs
+++ b/src/Restyler/Config/Restyler.hs
@@ -51,7 +51,11 @@ overrideRestylers restylers overrides =
     toEither $ case length $ filter ((== "*") . roName) overrides of
         0 -> explicits <$> getOverrides
         1 -> replaced restylers <$> getOverrides
-        _ -> Failure ["TODO"]
+        n -> Failure
+            [ "You may have at most 1 wildcard in restylers ("
+              <> show n
+              <> " found)"
+            ]
   where
     getOverrides = traverse (overrideRestyler restylersMap) overrides
 

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -253,7 +253,7 @@ assertTestConfig = either throwString pure <=< loadTestConfig
 showConfigError :: ConfigError -> String
 showConfigError = \case
     ConfigErrorInvalidYaml _ ex -> prettyPrintParseException ex
-    ConfigErrorUnknownRestylers errs -> unlines errs
+    ConfigErrorInvalidRestylers errs -> unlines errs
     ConfigErrorInvalidRestylersYaml ex -> show ex
 
 testRestylers :: [Restyler]

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -173,6 +173,37 @@ spec = do
                 ]
             }
 
+    it "supports * to indicate all other Restylers" $ example $ do
+        result <- assertTestConfig [st|
+            restylers:
+            - jdt
+            - "*"
+        |]
+
+        map (rName &&& rEnabled) (cRestylers result)
+            `shouldBe` [ ("jdt", True)
+                       , ("astyle", True)
+                       , ("autopep8", True)
+                       , ("black", True)
+                       , ("dfmt", True)
+                       , ("elm-format", True)
+                       , ("hindent", False)
+                       , ("pg_format", True)
+                       , ("php-cs-fixer", True)
+                       , ("prettier", True)
+                       , ("prettier-markdown", True)
+                       , ("prettier-ruby", True)
+                       , ("prettier-yaml", True)
+                       , ("reorder-python-imports", True)
+                       , ("rubocop", True)
+                       , ("rustfmt", True)
+                       , ("shellharden", True)
+                       , ("shfmt", True)
+                       , ("stylish-haskell", True)
+                       , ("terraform", True)
+                       , ("yapf", True)
+                       ]
+
     it "handles invalid indentation nicely" $ example $ do
         result <- loadTestConfig [st|
             restylers:
@@ -214,6 +245,10 @@ loadTestConfig content = do
         $ loadConfigFrom (ConfigContent $ encodeUtf8 $ dedent content)
         $ const
         $ pure testRestylers
+
+-- | Load a @'Text'@ as configuration, fail on errors
+assertTestConfig :: MonadIO m => Text -> m Config
+assertTestConfig = either throwString pure <=< loadTestConfig
 
 showConfigError :: ConfigError -> String
 showConfigError = \case

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -204,6 +204,48 @@ spec = do
                        , ("yapf", True)
                        ]
 
+    it "can place * anywhere" $ example $ do
+        result <- assertTestConfig [st|
+            restylers:
+            - jdt
+            - "*"
+            - autopep8
+        |]
+
+        map (rName &&& rEnabled) (cRestylers result)
+            `shouldBe` [ ("jdt", True)
+                       , ("astyle", True)
+                       , ("black", True)
+                       , ("dfmt", True)
+                       , ("elm-format", True)
+                       , ("hindent", False)
+                       , ("pg_format", True)
+                       , ("php-cs-fixer", True)
+                       , ("prettier", True)
+                       , ("prettier-markdown", True)
+                       , ("prettier-ruby", True)
+                       , ("prettier-yaml", True)
+                       , ("reorder-python-imports", True)
+                       , ("rubocop", True)
+                       , ("rustfmt", True)
+                       , ("shellharden", True)
+                       , ("shfmt", True)
+                       , ("stylish-haskell", True)
+                       , ("terraform", True)
+                       , ("yapf", True)
+                       , ("autopep8", True)
+                       ]
+
+    it "errors for more than one *" $ example $ do
+        result <- loadTestConfig [st|
+            restylers:
+            - "*"
+            - jdt
+            - "*"
+        |]
+
+        result `shouldSatisfy` hasError "1 wildcard"
+
     it "handles invalid indentation nicely" $ example $ do
         result <- loadTestConfig [st|
             restylers:


### PR DESCRIPTION
If present, this key represents *all other non-configured Restylers*. This
allows users who are configuring Restylers to still run all the other default
Restylers. It also allows them to define in what order they're run.

Use cases:

- Enable `jdt`, and keep all others running after

  ```yaml
  restylers:
    - jdt
    - "*"
  ```

- Enable `jdt`, and run it last

  ```yaml
  restylers:
    - "*"
    - jdt
  ```

- Ensure `stylish-haskell` runs before `brittany`, before all others

  ```yaml
  restylers:
    - stylish-haskell
    - brittany
    - "*"
  ```

- Run *only* `clang-format` (current production behavior)

  ```yaml
  restylers:
    - clang-format
  ```

- Run `clang-format`, `astyle`, everything else, then `clang-format` again with
  different options

  ```yaml
  restylers:
    - clang-format
    - astyle
    - "*"
    - clang-format:
        arguments: ["--special"]
        include:
          - "special/**/*.cs"
  ```