### PR TITLE
Allow for alternate restyled config locations

### DIFF
--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -34,6 +34,7 @@ module Restyler.Config
     , loadConfigFrom
     , resolveRestylers
     , defaultConfigContent
+    , configPaths
     )
 where
 

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -62,6 +62,7 @@ import Restyler.Config.Statuses
 import Restyler.PullRequest
 import Restyler.RemoteFile
 import Restyler.Restyler
+import Control.Monad.Trans.Maybe (MaybeT(..))
 
 -- | A polymorphic representation of @'Config'@
 --
@@ -209,10 +210,7 @@ readConfigSource = \case
 
 readFirstConfigSource
     :: HasSystem env => [ConfigSource] -> RIO env (Maybe ByteString)
-readFirstConfigSource = findJust . fmap readConfigSource
-
-findJust :: Monad m => [m (Maybe a)] -> m (Maybe a)
-findJust = foldM (\acc x -> maybe x (pure . Just) acc) Nothing
+readFirstConfigSource = runMaybeT . asum . fmap (MaybeT . readConfigSource)
 
 -- | Load configuration if present and apply defaults
 --

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -284,7 +284,7 @@ loadTestConfig content = do
     app <- liftIO $ testApp "/" []
     runRIO app
         $ tryTo showConfigError
-        $ loadConfigFrom (ConfigContent $ encodeUtf8 $ dedent content)
+        $ loadConfigFrom [ConfigContent $ encodeUtf8 $ dedent content]
         $ const
         $ pure testRestylers
 


### PR DESCRIPTION
This PR allows for alternate `restyled.yaml` configuration files closing #98 

I formatted the code with `brittany` using your configuration file.

I tried to write the most general `findJust` function possible. I tried two versions shown here: https://gist.github.com/chiroptical/2a921faa08976f6a176557fe57bb6021.

I would like to add a test to make sure it is working correctly.