### PR TITLE
Implement soft limit on changed paths

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -8,6 +8,10 @@ exclude:
   - "**/vendor/**/*"
   - ".github/workflows/**/*" # https://github.com/restyled-io/restyler/issues/73
 
+changed_paths:
+  maximum: 1000
+  outcome: error
+
 remote_files: []
 
 auto: false

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -55,6 +55,7 @@ import qualified Data.Yaml as Yaml
 import qualified Data.Yaml.Ext as Yaml
 import GitHub.Data (IssueLabel, User)
 import Restyler.App.Class
+import Restyler.Config.ChangedPaths
 import Restyler.Config.ExpectedKeys
 import Restyler.Config.Glob
 import Restyler.Config.RequestReview
@@ -82,6 +83,7 @@ import Restyler.Restyler
 data ConfigF f = ConfigF
     { cfEnabled :: f Bool
     , cfExclude :: f (SketchyList Glob)
+    , cfChangedPaths :: f ChangedPathsConfig
     , cfAuto :: f Bool
     , cfRemoteFiles :: f (SketchyList RemoteFile)
     , cfPullRequests :: f Bool
@@ -128,6 +130,7 @@ resolveConfig = bzipWith f
 data Config = Config
     { cEnabled :: Bool
     , cExclude :: [Glob]
+    , cChangedPaths :: ChangedPathsConfig
     , cAuto :: Bool
     , cRemoteFiles :: [RemoteFile]
     , cPullRequests :: Bool
@@ -248,6 +251,7 @@ resolveRestylers ConfigF {..} allRestylers = do
     pure Config
         { cEnabled = runIdentity cfEnabled
         , cExclude = unSketchy $ runIdentity cfExclude
+        , cChangedPaths = runIdentity cfChangedPaths
         , cAuto = runIdentity cfAuto
         , cRemoteFiles = unSketchy $ runIdentity cfRemoteFiles
         , cPullRequests = runIdentity cfPullRequests

--- a/src/Restyler/Config/ChangedPaths.hs
+++ b/src/Restyler/Config/ChangedPaths.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Restyler.Config.ChangedPaths
+    ( ChangedPathsConfig(..)
+    , MaximumChangedPathsOutcome(..)
+    )
+where
+
+import Restyler.Prelude
+
+import Data.Aeson
+import Data.Aeson.Casing
+import Restyler.Config.ExpectedKeys
+
+data ChangedPathsConfig = ChangedPathsConfig
+    { cpcMaximum :: Natural
+    , cpcOutcome :: MaximumChangedPathsOutcome
+    }
+    deriving (Eq, Show, Generic)
+
+instance FromJSON ChangedPathsConfig where
+    parseJSON = genericParseJSONValidated $ aesonPrefix snakeCase
+
+instance ToJSON ChangedPathsConfig where
+    toJSON = genericToJSON $ aesonPrefix snakeCase
+    toEncoding = genericToEncoding $ aesonPrefix snakeCase
+
+data MaximumChangedPathsOutcome
+    = MaximumChangedPathsOutcomeSkip
+    | MaximumChangedPathsOutcomeError
+    deriving (Eq, Show)
+
+instance FromJSON MaximumChangedPathsOutcome where
+    parseJSON = withText "MaximumChangedPathsOutcome" $ \case
+        "skip" -> pure MaximumChangedPathsOutcomeSkip
+        "error" -> pure MaximumChangedPathsOutcomeError
+        x -> fail $ "Invalid outcome " <> unpack x <> ", must be skip or error"
+
+instance ToJSON MaximumChangedPathsOutcome where
+    toJSON = \case
+        MaximumChangedPathsOutcomeSkip -> String "skip"
+        MaximumChangedPathsOutcomeError -> String "error"

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -17,6 +17,7 @@ import RIO.Char as X (isSpace)
 import RIO.List as X
     ( dropWhileEnd
     , find
+    , genericLength
     , headMaybe
     , maximumByMaybe
     , maximumMaybe

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -92,8 +92,9 @@ spec = do
                             }
                         f
 
-            runTestApp' (runRestyler_ someRestyler ["foo bar"])
-                `shouldThrow` isRestylerExitFailure someRestyler 99
+            runTestApp' (runRestyler_ someRestyler ["foo"]) `shouldThrow` \case
+                RestylerExitFailure re s _ -> re == someRestyler && s == 99
+                _ -> False
 
 mkPaths :: Int -> [FilePath]
 mkPaths n = map (\i -> "/" <> show i <> ".txt") [1 .. n]
@@ -111,7 +112,3 @@ setMaximum m cp = cp { cpcMaximum = m }
 
 setOutcomeSkip :: ChangedPathsConfig -> ChangedPathsConfig
 setOutcomeSkip cp = cp { cpcOutcome = MaximumChangedPathsOutcomeSkip }
-
-isRestylerExitFailure :: Restyler -> Int -> AppError -> Bool
-isRestylerExitFailure r se (RestylerExitFailure re s _) = re == r && se == s
-isRestylerExitFailure _ _ _ = False

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -58,20 +58,20 @@ spec = do
 
                 liftIO $ filtered `shouldBe` [[]]
 
-        describe "runRestyler_" $ do
-            it "treats non-zero exit codes as RestylerExitFailure" $ do
-                let
-                    runTestApp' f = do
-                        app <- testApp "/" []
-                        runRIO
-                            app
-                                { taCallProcessExitCode = \_ _ ->
-                                    pure $ ExitFailure 99
-                                }
-                            f
+    describe "runRestyler_" $ do
+        it "treats non-zero exit codes as RestylerExitFailure" $ do
+            let
+                runTestApp' f = do
+                    app <- testApp "/" []
+                    runRIO
+                        app
+                            { taCallProcessExitCode = \_ _ ->
+                                pure $ ExitFailure 99
+                            }
+                        f
 
-                runTestApp' (runRestyler_ someRestyler ["foo bar"])
-                    `shouldThrow` isRestylerExitFailure someRestyler 99
+            runTestApp' (runRestyler_ someRestyler ["foo bar"])
+                `shouldThrow` isRestylerExitFailure someRestyler 99
 
 isRestylerExitFailure :: Restyler -> Int -> AppError -> Bool
 isRestylerExitFailure r se (RestylerExitFailure re s _) = re == r && se == s

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -4,6 +4,10 @@ module SpecHelper
     , runTestApp
     , someRestyler
 
+    -- * Config
+    , loadDefaultConfig
+    , testRestylers
+
     -- * Re-exports
     , module X
     )
@@ -28,7 +32,9 @@ import Test.Hspec as X hiding
 import Test.Hspec.Expectations.Lifted as X
 import Test.QuickCheck as X
 
+import Data.Yaml (decodeThrow)
 import Restyler.App.Class
+import Restyler.Config
 import Restyler.Options
 import Restyler.Restyler
 import RIO.Test.FS (FS, HasFS(..))
@@ -132,3 +138,33 @@ asksAp3 :: MonadReader r m => (r -> a -> b -> c -> m d) -> a -> b -> c -> m d
 asksAp3 f x y z = do
     f' <- asks f
     f' x y z
+
+loadDefaultConfig :: RIO env Config
+loadDefaultConfig = do
+    config <- decodeThrow defaultConfigContent
+    resolveRestylers config testRestylers
+
+testRestylers :: [Restyler]
+testRestylers =
+    [ someRestyler { rName = "astyle" }
+    , someRestyler { rName = "autopep8" }
+    , someRestyler { rName = "black" }
+    , someRestyler { rName = "dfmt" }
+    , someRestyler { rName = "elm-format" }
+    , someRestyler { rName = "hindent", rEnabled = False }
+    , someRestyler { rName = "jdt", rEnabled = False }
+    , someRestyler { rName = "pg_format" }
+    , someRestyler { rName = "php-cs-fixer" }
+    , someRestyler { rName = "prettier" }
+    , someRestyler { rName = "prettier-markdown" }
+    , someRestyler { rName = "prettier-ruby" }
+    , someRestyler { rName = "prettier-yaml" }
+    , someRestyler { rName = "reorder-python-imports" }
+    , someRestyler { rName = "rubocop" }
+    , someRestyler { rName = "rustfmt" }
+    , someRestyler { rName = "shellharden" }
+    , someRestyler { rName = "shfmt" }
+    , someRestyler { rName = "stylish-haskell" }
+    , someRestyler { rName = "terraform" }
+    , someRestyler { rName = "yapf" }
+    ]


### PR DESCRIPTION
PRs with a high changed-paths count are typically not real PRs. They're most
often bots working to automatically keep mirrors in sync. These PRs also cause
backlogs because they can take much longer to restyle than our typical (real)
PRs.

This commits adds a configuration point for limiting this. If we see a PR with
over 1,000 changed files we will error. This prevents such mirror PRs from
impacting other users.

The actual maximum and the fact that we error are (separately) configurable by
users (i.e. it's a soft limit). A wiki page has been created and is linked from
the new AppError.