### PR TITLE
Move directory expansion into runRestyler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.cabal
+*.dump-hi
 *.t.err
 .env*
 !.env.test

--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -58,11 +58,19 @@ instance HasSystem StartupApp where
         logDebug $ "doesFileExist: " <> displayShow path
         appIO SystemError $ Directory.doesFileExist path
 
+    doesDirectoryExist path = do
+        logDebug $ "doesDirectoryExist: " <> displayShow path
+        appIO SystemError $ Directory.doesDirectoryExist path
+
     isFileExecutable path = do
         logDebug $ "isFileExecutable: " <> displayShow path
         appIO SystemError
             $ Directory.executable
             <$> Directory.getPermissions path
+
+    listDirectory path = do
+        logDebug $ "listDirectory: " <> displayShow path
+        appIO SystemError $ Directory.listDirectory path
 
     readFile path = do
         logDebug $ "readFile: " <> displayShow path
@@ -157,7 +165,9 @@ instance HasSystem App where
     getCurrentDirectory = runApp getCurrentDirectory
     setCurrentDirectory = runApp . setCurrentDirectory
     doesFileExist = runApp . doesFileExist
+    doesDirectoryExist = runApp . doesDirectoryExist
     isFileExecutable = runApp . isFileExecutable
+    listDirectory = runApp . listDirectory
     readFile = runApp . readFile
     readFileBS = runApp . readFileBS
 

--- a/src/Restyler/App/Class.hs
+++ b/src/Restyler/App/Class.hs
@@ -35,7 +35,11 @@ class HasSystem env where
 
     doesFileExist :: FilePath -> RIO env Bool
 
+    doesDirectoryExist :: FilePath -> RIO env Bool
+
     isFileExecutable :: FilePath -> RIO env Bool
+
+    listDirectory :: FilePath -> RIO env [FilePath]
 
     readFile :: FilePath -> RIO env Text
 

--- a/test/RIO/Test/FS.hs
+++ b/test/RIO/Test/FS.hs
@@ -25,7 +25,7 @@ module RIO.Test.FS
     , writeFileUnreadable
     , getCurrentDirectory
     , setCurrentDirectory
-    , doesPathExist
+    -- , doesPathExist
     , doesFileExist
     , doesDirectoryExist
     , isFileExecutable

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -96,6 +96,20 @@ spec = do
                 RestylerExitFailure re s _ -> re == someRestyler && s == 99
                 _ -> False
 
+    describe "findFiles" $ do
+        it "expands and excludes" $ do
+            app <- testApp
+                "/foo"
+                [ ("/foo/bar/baz/bat", "")
+                , ("/foo/bar/baz/quix", "")
+                , ("/foo/bat/baz", "")
+                , ("/foo/foo", "")
+                , ("/foo/xxx", "")
+                ]
+
+            runRIO app (findFiles ["bar/baz", "bat", "xxx", "zzz"])
+                `shouldReturn` ["bar/baz/bat", "bar/baz/quix", "bat/baz", "xxx"]
+
 mkPaths :: Int -> [FilePath]
 mkPaths n = map (\i -> "/" <> show i <> ".txt") [1 .. n]
 

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -106,7 +106,9 @@ instance HasSystem TestApp where
     getCurrentDirectory = FS.getCurrentDirectory
     setCurrentDirectory = FS.setCurrentDirectory
     doesFileExist = FS.doesFileExist
+    doesDirectoryExist = FS.doesDirectoryExist
     isFileExecutable = FS.isFileExecutable
+    listDirectory = FS.listDirectory
 
 instance HasProcess TestApp where
     callProcess = asksAp2 taCallProcess


### PR DESCRIPTION
This allows it to come after global exclusions are applied. The presence of
symlinks can cause this to loop. This is an edge-case but, without being able to
globally exclude before expansion, was not able to be worked around by the user
in the obvious way.

Fixes #94.