### PR TITLE
Make commit message conform to conventional commits standard

### DIFF
--- a/src/Restyler/RestylerResult.hs
+++ b/src/Restyler/RestylerResult.hs
@@ -63,4 +63,4 @@ getRestyleOutcome restyler = do
     if null changedPaths
         then pure NoChanges
         else ChangesCommitted changedPaths . pack <$> gitCommitAll commitMessage
-    where commitMessage = "Restyled by " <> rName restyler
+    where commitMessage = "style: Restyled by " <> rName restyler


### PR DESCRIPTION
## Before this PR
If you use restyled.io on a repo that you also use any sort of commit message linting or automatic changelog generation for, then the commit messages from restyled.io runs have to either be ignored manually (e.g. by changing your commit linter config) or amended by hand. 

# This PR
I propose that this change to include the standard prefix `style:` which ensures that these commits are at least typed properly by most systems. For users that do not do any sort of commit linting/semantic commits/automatic changelog generation, the only difference they observe are that commit messages are slightly different

For users with GitHub bots/apps that might normally block this PR, then they no longer have to worry about either manually overriding with admin merges, modifying commit messages, or modifying their workflow. 

Impact overall: minimal either way but it would be a nice to have