### PR TITLE
Suppress TTY forwarding and interactive when stdin is not a TTY

### DIFF
--- a/bin/restyle-path
+++ b/bin/restyle-path
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Invocation script for a simpler restyle-path executable, which will restyle
 # all given paths locally.
@@ -25,7 +25,11 @@
 ###
 : "${RESTYLER_TAG:=:master-final}"
 
-exec docker run -it --rm \
+declare -a it=( )
+
+[[ -t 0 ]] && it+=( -it  )
+
+exec docker run "${it[@]}" --rm \
   --env DEBUG=1 \
   --env HOST_DIRECTORY="$PWD" \
   --env UNRESTRICTED=1 \

--- a/bin/restyle-path
+++ b/bin/restyle-path
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Invocation script for a simpler restyle-path executable, which will restyle
 # all given paths locally.
@@ -25,11 +25,15 @@
 ###
 : "${RESTYLER_TAG:=:master-final}"
 
-declare -a it=( )
+docker_run() {
+    if [ -t 0 ]; then
+        exec docker run -it "$@"
+    else
+        exec docker run -i "$@"
+    fi
+}
 
-[[ -t 0 ]] && it+=( -it  )
-
-exec docker run "${it[@]}" --rm \
+docker_run --rm \
   --env DEBUG=1 \
   --env HOST_DIRECTORY="$PWD" \
   --env UNRESTRICTED=1 \


### PR DESCRIPTION
#### Problem
 restyle-path can't be used with xargs or other invocation schemes that hand the script a pipe or other device for stdin

 #### Proposed Changes
 1. use bash (for array variables)
 2. only forward the TTY and run interactively if stdin is a TTY