### PR TITLE
Ignore symbolic links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,3 @@
-# This PR has differences such that all Restylers known at the time I made it
-# will run, making it a great test PR.
-INTEGRATION_PULL_REQUEST ?= restyled-io/demo\#45
-INTEGRATION_APP_ENV ?= dev
-INTEGRATION_INSTALLATION_ID ?= 58920
-INTEGRATION_RESTYLER_IMAGE ?= restyled/restyler
-INTEGRATION_RESTYLER_TAG ?= :latest
-INTEGRATION_RESTYLER_BUILD ?= 1
-
 all: setup setup.lint setup.tools build lint test
 
 .PHONY: setup
@@ -48,22 +39,6 @@ image:
 	  --build-arg "REVISION=testing" \
 	  --tag restyled/restyler \
 	  .
-
-.PHONY: test.integration
-test.integration:
-	if [ "$(INTEGRATION_RESTYLER_BUILD)" -eq 1 ]; then \
-	  $(MAKE) image && \
-	  docker tag restyled/restyler \
-	    $(INTEGRATION_RESTYLER_IMAGE)$(INTEGRATION_RESTYLER_TAG); \
-	fi
-	docker run -it --rm \
-	  --env DEBUG=1 \
-	  --env GITHUB_ACCESS_TOKEN=$$(cd ../ops && ./tools/get-access-token $(INTEGRATION_APP_ENV) $(INTEGRATION_INSTALLATION_ID)) \
-	  --volume /tmp:/tmp \
-	  --volume /var/run/docker.sock:/var/run/docker.sock \
-	  $(INTEGRATION_RESTYLER_IMAGE)$(INTEGRATION_RESTYLER_TAG) \
-	    --job-url https://example.com \
-	    --color=always "$(INTEGRATION_PULL_REQUEST)"
 
 AWS ?= aws --profile restyled-ci
 

--- a/restyle-path/main.hs
+++ b/restyle-path/main.hs
@@ -34,6 +34,7 @@ instance HasSystem App where
     doesFileExist = Directory.doesFileExist
     doesDirectoryExist = Directory.doesDirectoryExist
     isFileExecutable = fmap Directory.executable . Directory.getPermissions
+    isFileSymbolicLink = Directory.pathIsSymbolicLink
     listDirectory = Directory.listDirectory
     readFile = readFileUtf8
     readFileBS = readFileBinary

--- a/restyle-path/main.hs
+++ b/restyle-path/main.hs
@@ -88,4 +88,3 @@ main = do
             , oUnrestricted = eoUnrestricted
             }
         }
-

--- a/restyle-path/main.hs
+++ b/restyle-path/main.hs
@@ -1,4 +1,7 @@
-module Main (main) where
+module Main
+    ( main
+    )
+where
 
 import RIO
 

--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -69,6 +69,10 @@ instance HasSystem StartupApp where
             $ Directory.executable
             <$> Directory.getPermissions path
 
+    isFileSymbolicLink path = do
+        logDebug $ "isFileSymbolicLink: " <> displayShow path
+        appIO SystemError $ Directory.pathIsSymbolicLink path
+
     listDirectory path = do
         logDebug $ "listDirectory: " <> displayShow path
         appIO SystemError $ Directory.listDirectory path
@@ -172,6 +176,7 @@ instance HasSystem App where
     doesFileExist = runApp . doesFileExist
     doesDirectoryExist = runApp . doesDirectoryExist
     isFileExecutable = runApp . isFileExecutable
+    isFileSymbolicLink = runApp . isFileSymbolicLink
     listDirectory = runApp . listDirectory
     readFile = runApp . readFile
     readFileBS = runApp . readFileBS

--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -2,7 +2,8 @@ module Restyler.App
     ( App(..)
     , StartupApp(..)
     , bootstrapApp
-    ) where
+    )
+where
 
 import Restyler.Prelude
 

--- a/src/Restyler/App/Class.hs
+++ b/src/Restyler/App/Class.hs
@@ -39,6 +39,8 @@ class HasSystem env where
 
     isFileExecutable :: FilePath -> RIO env Bool
 
+    isFileSymbolicLink :: FilePath -> RIO env Bool
+
     listDirectory :: FilePath -> RIO env [FilePath]
 
     readFile :: FilePath -> RIO env Text

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -39,6 +39,11 @@ withRIO f m = do
     env <- asks f
     runRIO env m
 
+guardM :: (Monad m, Alternative m) => m Bool -> m ()
+guardM mb = do
+    b <- mb
+    guard b
+
 -- | Decode known-valid UTF-8
 --
 -- Uses @'lenientDecode'@:

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -14,6 +14,7 @@ where
 
 import Restyler.Prelude
 
+import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Data.List (nub)
 import Restyler.App.Class
 import Restyler.App.Error
@@ -231,6 +232,7 @@ findFiles = fmap concat . traverse go
             then do
                 files <- listDirectory parent
                 findFiles $ map (parent </>) files
-            else do
-                isFile <- doesFileExist parent
-                pure [ parent | isFile ] -- too clever?
+            else fmap maybeToList $ runMaybeT $ do
+                guardM $ lift $ doesFileExist parent
+                guardM $ lift $ not <$> isFileSymbolicLink parent
+                pure parent

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -12,7 +12,8 @@ import Restyler.Config.Interpreter
 import Restyler.Restyler
 import Restyler.Restyler.Run
 import qualified RIO
-import RIO.Test.FS (writeFileExecutable, writeFileUnreadable, writeFileUtf8)
+import RIO.Test.FS
+    (createFileLink, writeFileExecutable, writeFileUnreadable, writeFileUtf8)
 
 spec :: Spec
 spec = do
@@ -106,6 +107,14 @@ spec = do
 
             runRIO app (findFiles ["bar/baz", "bat", "xxx", "zzz"])
                 `shouldReturn` ["bar/baz/bat", "bar/baz/quix", "bat/baz", "xxx"]
+
+        it "excludes symlinks" $ do
+            app <- testApp "/" []
+            runRIO app $ do
+                writeFileUtf8 "/foo/bar" ""
+                createFileLink "/foo/bar" "/foo/baz/bat"
+
+                findFiles ["foo"] `shouldReturn` ["foo/bar"]
 
 mkPaths :: Int -> [FilePath]
 mkPaths n = map (\i -> "/" <> show i <> ".txt") [1 .. n]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -109,6 +109,7 @@ instance HasSystem TestApp where
     doesFileExist = FS.doesFileExist
     doesDirectoryExist = FS.doesDirectoryExist
     isFileExecutable = FS.isFileExecutable
+    isFileSymbolicLink = FS.isFileSymbolicLink
     listDirectory = FS.listDirectory
 
 instance HasProcess TestApp where

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -13,22 +13,23 @@ module SpecHelper
     )
 where
 
-import Restyler.Prelude as X hiding
-    (readFileBinary, readFileUtf8, writeFileUtf8)
-import Test.Hspec as X hiding
-    ( expectationFailure
-    , shouldBe
-    , shouldContain
-    , shouldEndWith
-    , shouldMatchList
-    , shouldNotBe
-    , shouldNotContain
-    , shouldNotReturn
-    , shouldNotSatisfy
-    , shouldReturn
-    , shouldSatisfy
-    , shouldStartWith
-    )
+import Restyler.Prelude as X
+    hiding (readFileBinary, readFileUtf8, writeFileUtf8)
+import Test.Hspec as X
+    hiding
+        ( expectationFailure
+        , shouldBe
+        , shouldContain
+        , shouldEndWith
+        , shouldMatchList
+        , shouldNotBe
+        , shouldNotContain
+        , shouldNotReturn
+        , shouldNotSatisfy
+        , shouldReturn
+        , shouldSatisfy
+        , shouldStartWith
+        )
 import Test.Hspec.Expectations.Lifted as X
 import Test.QuickCheck as X
 


### PR DESCRIPTION
Symlinks aren't anything useful for us. If they point at a file in the 
repository, and if that file needs Restyling, we will see it directly. If
they point outside the repository or to themselves it can cause us a lot of
trouble.

Due to the symmetry with isFileExecutable, we chose to make our own name 
and not call this isPathSymbolicLink to match System.Directory.

Closes restyled-io/restyled.io#213.