### PR TITLE
Use shallow clone and incremental strategies

### DIFF
--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -197,7 +197,7 @@ instance HasProcess App where
 
 instance HasGit App where
     gitPushForce branch =
-        callProcess "git" ["push", "--force-with-lease", "origin", branch]
+        callProcess "git" ["push", "--force", "origin", branch]
     gitDiffNameOnly mRef = do
         let args = ["diff", "--name-only"] <> maybeToList mRef
         lines <$> readProcess "git" args ""


### PR DESCRIPTION
A shallow clone is much, much faster on a big repository. However, it
comes with limitations:

1. We need to find changed files against the base, which means we need
   to fetch some distance back on the base branch until we find that
   commit

   To support this, we incrementally fetch the base branch with
   increasing depths until we find our commit (or fail).

2. We need to push updates on top of the clone

   Using --force-with-lease seemed to always error with stale info,
   presumably because a shallow clone just doesn't have what it needs to
   do it's check. This may be bug in git, but we can move to --force and
   accept some bad behavior in race conditions in exchange for these
   faster clones.

   If you google about pushing from a shallow-clone, most references
   indicate it shouldn't work at all -- so I'll take this as a win.

The head side of a shallow clone should work equally well for a real
branch or the virtual PR ref of a fork. Therefore, we can remove those
paths. We removed the auto-push feature, which may have been impacted by
that, just to avoid any issues.
