### PR TITLE
Annotate line/column in YamlParseExceptions

### DIFF
--- a/restyler.cabal
+++ b/restyler.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 443eb4772b2089c7edd536ab78be8ec8da93137972750344ab95b96463bba6a7
+-- hash: 5008444158185b73a66b309c6c7e003c09d1ec1b1ff66a848858530a3b3bd2d2
 
 name:           restyler
 version:        0.2.0.0
@@ -200,6 +200,7 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Data.Yaml.ExtSpec
       Restyler.CommitTemplateSpec
       Restyler.Config.ExpectedKeysSpec
       Restyler.Config.IncludeSpec

--- a/src/Data/Yaml/Ext.hs
+++ b/src/Data/Yaml/Ext.hs
@@ -1,10 +1,13 @@
 module Data.Yaml.Ext
     ( modifyInvalidYaml
     , modifyYamlProblem
+    , locateErrorInContent
     ) where
 
 import Prelude
 
+import Data.Text (Text, pack)
+import qualified Data.Text as T
 import Data.Yaml
 
 modifyInvalidYaml
@@ -29,3 +32,38 @@ modifyYamlProblem f = modifyInvalidYaml $ \case
     ex@YamlException{} -> ex
     YamlParseException problem context problemMark ->
         YamlParseException (f problem) context problemMark
+
+locateErrorInContent :: ParseException -> Text -> Text
+locateErrorInContent = \case
+    AesonException{} -> id
+    OtherParseException{} -> id
+    NonStringKey{} -> id
+    NonStringKeyAlias{} -> id
+    CyclicIncludes{} -> id
+    LoadSettingsException{} -> id
+    MultipleDocuments{} -> id
+
+    InvalidYaml (Just YamlParseException {..}) -> locateLineColumn
+        (pack yamlProblem)
+        (yamlLine yamlProblemMark)
+        (yamlColumn yamlProblemMark)
+
+    InvalidYaml{} -> id
+    NonScalarKey{} -> id
+    UnknownAlias{} -> id
+    UnexpectedEvent{} -> id
+
+locateLineColumn :: Text -> Int -> Int -> Text -> Text
+locateLineColumn problem line column =
+    T.unlines . uncurry insertMark . splitAt line . T.lines
+  where
+    insertMark before after = before <> marks <> after
+
+    columnSpacing = T.replicate (column - 1) " "
+
+    marks =
+        [ columnSpacing <> "▲"
+        , columnSpacing <> "│"
+        , columnSpacing <> "└ " <> problem
+        , ""
+        ]

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -184,7 +184,7 @@ instance Exception ConfigError where
             , pack $ Yaml.prettyPrintParseException e
             , ""
             , "Original input:"
-            , decodeUtf8 yaml
+            , Yaml.locateErrorInContent e $ decodeUtf8 yaml
             , ""
             , generalHelp
             ]

--- a/test/Data/Yaml/ExtSpec.hs
+++ b/test/Data/Yaml/ExtSpec.hs
@@ -1,0 +1,50 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Data.Yaml.ExtSpec
+    ( spec
+    ) where
+
+import SpecHelper
+
+import Data.Aeson
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+import Data.Yaml.Ext
+
+spec :: Spec
+spec = do
+    describe "locateErrorInContent" $ do
+        it "adds an annotation pointing out line/column" $ example $ do
+            let invalidYaml = T.unlines
+                    [ "restylers:"
+                    , "  - brittany"
+                    , "      include:"
+                    , "        - '**/*.hs'"
+                    , "        - '!src/Graphula/Class.hs' # CPP"
+                    , "  - stylish-haskell"
+                    , ""
+                    , "comments: false"
+                    , ""
+                    , "labels:"
+                    , "  - restyled"
+                    ]
+
+                Left ex = Yaml.decodeEither' @Value $ encodeUtf8 invalidYaml
+
+            locateErrorInContent ex invalidYaml `shouldBe` T.unlines
+                [ "restylers:"
+                , "  - brittany"
+                , "            ▲"
+                , "            │"
+                , "            └ mapping values are not allowed in this context"
+                , ""
+                , "      include:"
+                , "        - '**/*.hs'"
+                , "        - '!src/Graphula/Class.hs' # CPP"
+                , "  - stylish-haskell"
+                , ""
+                , "comments: false"
+                , ""
+                , "labels:"
+                , "  - restyled"
+                ]


### PR DESCRIPTION
Example:

```
restylers:
  - brittany
            ▲
            │
            └ mapping values are not allowed in this context

      include:
        - '**/*.hs'
        - '!src/Graphula/Class.hs' # CPP
  - stylish-haskell

comments: false

labels:
  - restyled
```
