### PR TITLE
Add config.also_exclude

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -8,6 +8,8 @@ exclude:
   - "**/vendor/**/*"
   - ".github/workflows/**/*" # https://github.com/restyled-io/restyler/issues/73
 
+also_exclude: []
+
 changed_paths:
   maximum: 1000
   outcome: error

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -79,6 +79,7 @@ import UnliftIO.Exception (handle)
 data ConfigF f = ConfigF
     { cfEnabled :: f Bool
     , cfExclude :: f (SketchyList (Glob FilePath))
+    , cfAlsoExclude :: f (SketchyList (Glob FilePath))
     , cfChangedPaths :: f ChangedPathsConfig
     , cfAuto :: f Bool
     , cfCommitTemplate :: f CommitTemplate
@@ -128,7 +129,7 @@ resolveConfig = bzipWith f
 --
 data Config = Config
     { cEnabled :: Bool
-    , cExclude :: [Glob FilePath]
+    , cExclude :: Set (Glob FilePath)
     , cChangedPaths :: ChangedPathsConfig
     , cAuto :: Bool
     , cCommitTemplate :: CommitTemplate
@@ -291,7 +292,8 @@ resolveRestylers ConfigF {..} allRestylers = do
 
     pure Config
         { cEnabled = runIdentity cfEnabled
-        , cExclude = unSketchy $ runIdentity cfExclude
+        , cExclude =
+            Set.fromList $ unSketchy $ runIdentity $ cfExclude <> cfAlsoExclude
         , cChangedPaths = runIdentity cfChangedPaths
         , cAuto = runIdentity cfAuto
         , cCommitTemplate = runIdentity cfCommitTemplate

--- a/src/Restyler/Config/Glob.hs
+++ b/src/Restyler/Config/Glob.hs
@@ -17,7 +17,7 @@ import System.FilePath.Glob hiding (match)
 import qualified System.FilePath.Glob as Glob
 
 newtype Glob a = Glob { unGlob :: String }
-    deriving stock (Eq, Generic)
+    deriving stock (Eq, Ord, Generic)
     deriving newtype Show
 
 instance FromJSON (Glob a) where

--- a/src/Restyler/Config/SketchyList.hs
+++ b/src/Restyler/Config/SketchyList.hs
@@ -11,6 +11,9 @@ import Data.Aeson.Types (typeMismatch)
 data SketchyList a = One a | Many [a]
     deriving stock (Eq, Show)
 
+instance Semigroup (SketchyList a) where
+    a <> b = Many $ unSketchy a <> unSketchy b
+
 unSketchy :: SketchyList a -> [a]
 unSketchy (One i) = [i]
 unSketchy (Many is) = is


### PR DESCRIPTION
The current `exclude` could (and can still) be used to fully set what we
exclude, but in order to simply add a new pattern, you have to know,
re-specify, and forever maintain, our default choices in your own
config. This is annoying and error-prone.

The new key supports simply adding a pattern while continuing to respect
ours, even if they change in the future.

Closes #177.
