### PR TITLE
Tweak Restyler starting log message

### DIFF
--- a/src/Restyler/ErrorMetadata.hs
+++ b/src/Restyler/ErrorMetadata.hs
@@ -13,7 +13,8 @@ import Restyler.Prelude
 import Data.Aeson (ToJSON)
 import Restyler.App (GitHubError(..))
 import Restyler.Config (ConfigError(..))
-import Restyler.Restyler.Run (RestylerExitFailure(..), TooManyChangedPaths(..))
+import Restyler.Restyler.Run
+    (RestylerExitFailure(..), RestylerOutOfMemory(..), TooManyChangedPaths(..))
 import Restyler.Setup (CloneTimeoutError(..))
 
 data ErrorMetadata = ErrorMetadata
@@ -74,6 +75,13 @@ handlers e =
             , tag = "restyler"
             , description = "a Restyler errored"
             , exitCode = 20
+            }
+    , fromException e & First <&> \case
+        RestylerOutOfMemory{} -> ErrorMetadata
+            { severity = "error"
+            , tag = "restyler-oom"
+            , description = "a Restyler has used too much memory"
+            , exitCode = 21
             }
     , fromException e & First <&> \case
         TooManyChangedPaths{} -> ErrorMetadata

--- a/src/Restyler/Setup.hs
+++ b/src/Restyler/Setup.hs
@@ -37,10 +37,11 @@ restylerSetup
 restylerSetup = do
     Options {..} <- view optionsL
 
-    logInfo "Restyler starting"
-    pullRequest <- runGitHub $ pullRequestR oOwner oRepo oPullRequest
+    logInfo
+        $ "Restyler started"
+        :# ["owner" .= oOwner, "repo" .= oRepo, "pull" .= oPullRequest]
 
-    logInfo $ "Restyling PR" :# ["number" .= pullRequestNumber pullRequest]
+    pullRequest <- runGitHub $ pullRequestR oOwner oRepo oPullRequest
 
     when (pullRequestIsClosed pullRequest) $ do
         mRestyledPullRequest <- findRestyledPullRequest pullRequest


### PR DESCRIPTION
We're experimenting with database-less operation. This means we would
like to know owner/repo/pull and outcome purely from the stored Job log.

With this change, we are now uniformly emitting:

- Restyler started -> owner/repo/pull
- Restyler done -> exitCode

From that we can work out what we want to display.
