### PR TITLE
Optionally parse individual image parts

### DIFF
--- a/restyler.cabal
+++ b/restyler.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 31cb5d7b08d8211068df594604891bf3a2e425d20a7a24ed4c529f36911481b8
+-- hash: 96216864b988d5fa1f4bb2ecf7696ed5aa593345d8a946552299187955a0e9fe
 
 name:           restyler
 version:        0.2.0.0
@@ -24,6 +24,7 @@ library
       Restyler.Config.ChangedPaths
       Restyler.Config.ExpectedKeys
       Restyler.Config.Glob
+      Restyler.Config.Image
       Restyler.Config.Include
       Restyler.Config.Interpreter
       Restyler.Config.RequestReview

--- a/src/Restyler/Config/Image.hs
+++ b/src/Restyler/Config/Image.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DerivingVia #-}
+
+module Restyler.Config.Image
+  ( Image
+  , overrideRestylerImage
+  ) where
+
+import Restyler.Prelude hiding (First (..))
+
+import Data.Aeson
+import Data.Aeson.Types (typeMismatch)
+import Data.Semigroup (First (..))
+import Data.Semigroup.Generic
+import qualified Data.Text as T
+
+data ImageFields = ImageFields
+  { registry :: Maybe (First Text)
+  , name :: Maybe (First Text)
+  , tag :: Maybe (First Text)
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+  deriving (Semigroup) via (GenericSemigroupMonoid ImageFields)
+
+imageFieldsFromText :: Text -> ImageFields
+imageFieldsFromText base = case safeBreakOnStrip "/" base of
+  Nothing -> case safeBreakOnStrip ":" base of
+    Nothing ->
+      ImageFields
+        { registry = Nothing
+        , name = Just $ First base
+        , tag = Nothing
+        }
+    Just (name, tag) ->
+      ImageFields
+        { registry = Nothing
+        , name = Just $ First name
+        , tag = Just $ First tag
+        }
+  Just (registry, rest) -> case safeBreakOnStrip ":" rest of
+    Nothing ->
+      ImageFields
+        { registry = Just $ First registry
+        , name = Just $ First rest
+        , tag = Nothing
+        }
+    Just (name, tag) ->
+      ImageFields
+        { registry = Just $ First registry
+        , name = Just $ First name
+        , tag = Just $ First tag
+        }
+
+safeBreakOnStrip :: Text -> Text -> Maybe (Text, Text)
+safeBreakOnStrip x = bitraverse pure (T.stripPrefix x) . T.breakOn x
+
+imageFieldsFromString :: String -> ImageFields
+imageFieldsFromString = imageFieldsFromText . pack
+
+imageFieldsToText :: ImageFields -> Text
+imageFieldsToText ImageFields {..} =
+  mconcat
+    [ maybe "" ((<> "/") . getFirst) registry
+    , maybe "" getFirst name
+    , maybe "" ((":" <>) . getFirst) tag
+    ]
+
+imageFieldsToString :: ImageFields -> String
+imageFieldsToString = unpack . imageFieldsToText
+
+data Image = Image Text | ImageOverride ImageFields
+  deriving stock (Eq, Show, Generic)
+
+instance FromJSON Image where
+  parseJSON = \case
+    v@String {} -> Image <$> parseJSON v
+    v@Object {} -> ImageOverride <$> parseJSON v
+    v -> typeMismatch "String or Object" v
+
+instance ToJSON Image where
+  toJSON = \case
+    Image i -> toJSON i
+    ImageOverride fs -> toJSON fs
+  toEncoding = \case
+    Image i -> toEncoding i
+    ImageOverride fs -> toEncoding fs
+
+overrideRestylerImage :: String -> Image -> String
+overrideRestylerImage base = \case
+  Image i -> unpack i
+  ImageOverride fs -> imageFieldsToString $ fs <> imageFieldsFromString base

--- a/src/Restyler/Config/Restyler.hs
+++ b/src/Restyler/Config/Restyler.hs
@@ -14,6 +14,7 @@ import Data.Aeson.Types (Parser, modifyFailure)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Validation
 import Restyler.Config.ExpectedKeys
+import Restyler.Config.Image
 import Restyler.Config.Include
 import Restyler.Config.Interpreter
 import Restyler.Config.SketchyList
@@ -23,7 +24,7 @@ import Restyler.Restyler
 data RestylerOverride = RestylerOverride
   { roName :: String
   , roEnabled :: Maybe Bool
-  , roImage :: Maybe String
+  , roImage :: Maybe Image
   , roCommand :: Maybe (SketchyList String)
   , roArguments :: Maybe (SketchyList String)
   , roInclude :: Maybe (SketchyList Include)
@@ -101,7 +102,7 @@ overrideRestyler restylers RestylerOverride {..}
   override restyler@Restyler {..} =
     restyler
       { rEnabled = fromMaybe True roEnabled
-      , rImage = fromMaybe rImage roImage
+      , rImage = maybe rImage (overrideRestylerImage rImage) roImage
       , rCommand = maybe rCommand unSketchy roCommand
       , rArguments = maybe rArguments unSketchy roArguments
       , rInclude = maybe rInclude unSketchy roInclude

--- a/test/Restyler/ConfigSpec.hs
+++ b/test/Restyler/ConfigSpec.hs
@@ -78,6 +78,29 @@ spec = withTestApp $ do
       |]
       "ghcr.io/my-stylish:v1.0"
 
+  it "allows re-configuring specific image fields" $ testAppExample $ do
+    assertLoadsRestyler
+      rImage
+      [st|
+        restylers:
+          - stylish-haskell:
+              image:
+                registry: ghcr.io
+      |]
+      "ghcr.io/restyler-stylish-haskell:v1.0.0"
+
+  it "allows re-configuring more than one image field" $ testAppExample $ do
+    assertLoadsRestyler
+      rImage
+      [st|
+        restylers:
+          - stylish-haskell:
+              image:
+                name: my-stylish
+                tag: v5.1
+      |]
+      "restyled/my-stylish:v5.1"
+
   it "has good errors for unknown name" $ testAppExample $ do
     result1 <-
       loadTestConfig


### PR DESCRIPTION
Currently, users have to specify a full image or not,

```yaml
image: restyled/restyler-foo:v1.0.0
```

This means that to use an alternative tag, they have to get the registry
and name right.

This patch makes it possible to specify an object of fields,

```yaml
image:
  registry: restyled
  name: restyler-foo
  tag: v1.0.0
```

All fields are optional and will default from the manifest image, which
means users can simply override `tag` and not worry about the rest,

```yaml
image:
  tag: v1.0.0
```

This will be useful when we start shipping "series" tags and users will
be interacting with this point of configuration more.

```yaml
image:
  tag: v1
```
