### PR TITLE
Address ENV parsing errors on --help

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: restyler
-version: 0.3.0.0
+version: 0.3.0.1
 license: MIT
 
 language: GHC2021

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           restyler
-version:        0.3.0.0
+version:        0.3.0.1
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/src/Restyler/Local/App.hs
+++ b/src/Restyler/Local/App.hs
@@ -35,14 +35,17 @@ instance HasLogger App where
 
 withApp :: (App -> IO a) -> IO a
 withApp f = do
+  (opt, paths) <- Opt.parse "Restyle local files" (Env.helpDoc envParser) optp
+
   env <- Env.parse id envParser
-  (opt, paths) <-
-    Opt.parse "Restyle local files"
-      $ (,)
-      <$> optParser
-      <*> some1 (Opt.argument Opt.str $ Opt.metavar "PATH")
 
   let options = env <> opt
 
   withLogger (resolveLogSettings options.logSettings) $ \logger -> do
     f $ App {logger, options, paths}
+ where
+  optp :: Opt.Parser (Options, NonEmpty FilePath)
+  optp =
+    (,)
+      <$> optParser
+      <*> some1 (Opt.argument Opt.str $ Opt.metavar "PATH")

--- a/src/Restyler/Opt.hs
+++ b/src/Restyler/Opt.hs
@@ -6,12 +6,36 @@ where
 
 import Restyler.Prelude
 
+import Data.List qualified as List
 import Options.Applicative
+import Options.Applicative.Help.Chunk
 
 parse
   :: String
   -- ^ Description
+  -> String
+  -- ^ Footer
   -> Parser a
   -- ^ Options parser
   -> IO a
-parse d p = execParser $ info (p <**> helper) $ fullDesc <> progDesc d
+parse d f p =
+  execParser
+    $ info (p <**> helper)
+    $ fullDesc
+    <> progDesc d
+    <> footerLines f
+
+-- |
+--
+-- The 'footer' function takes a string, but then makes it a doc with
+-- 'paragraph' which replaces all newlines with spaces. Fun. This function
+-- preserves newlines at least, so the simple case of a pre-pretty-printed
+-- string is hanlded somewhat better.
+footerLines :: String -> InfoMod a
+footerLines =
+  footerDoc
+    . Just
+    . extractChunk
+    . vcatChunks
+    . map stringChunk
+    . List.lines


### PR DESCRIPTION
Since `restyle-gha` has required ENV (`GITHUB_TOKEN`), it was failing
when we run `--help`. We can correct this by parsing ENV after options.

Additionally, we can extract the help from the ENV parser and add it as
a footer to `--help`. That help doc isn't great, but it's better than
nothing for now, and we may upstream improvements.