### PR TITLE
Implement --manifest and --image-cleanup, internal refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ curl --proto '=https' --tlsv1.2 -sSf \
 ## Usage
 
 ```console
-Usage: restyle [--debug] [--trace] [--color WHEN] [--host-directory DIRECTORY]
-               [--no-commit] [--fail-on-differences] PATH [PATH]
+Usage: restyle [--debug] [--trace] [--color WHEN] [--fail-on-differences] 
+               [--host-directory DIRECTORY] [--image-cleanup] [--manifest FILE] 
+               [--no-commit] PATH [PATH]
 
   Restyle local files
 
@@ -21,24 +22,40 @@ Available options:
   --debug                  Enable debug logging
   --trace                  Enable trace logging
   --color WHEN             When to use color: always|never|auto
+  --fail-on-differences    Exit non-zero if differences were found
   --host-directory DIRECTORY
                            Working directory on host, if dockerized
+  --image-cleanup          Remove pulled restyler images after restyling
+  --manifest FILE          Restylers manifest to use
   --no-commit              Don't make commits for restyle changes
-  --fail-on-differences    Exit non-zero if differences were found
   -h,--help                Show this help text
 
 Available environment variables:
-  FAIL_ON_DIFFERENCES    Exit non-zero if differences were
+  FAIL_ON_DIFFERENCES
+                         Exit non-zero if differences were
                          found
   HOST_DIRECTORY         Working directory on host, if
                          dockerized
+  IMAGE_CLEANUP          Remove pulled restyler images
+                         after restyling
+  LOG_BREAKPOINT
+  LOG_COLOR
+  LOG_CONCURRENCY
+  LOG_DESTINATION
+  LOG_FORMAT
+  LOG_LEVEL
+  MANIFEST               Restylers manifest to use
+  NO_COLOR
   NO_COMMIT              Don't make commits for restyle
                          changes
-  RESTYLER_CPU_SHARES    Run restylers with
+  RESTYLER_CPU_SHARES
+                         Run restylers with
                          --cpu-shares=<number>
   RESTYLER_MEMORY        Run restylers with
                          --memory=<number>[b|k|m|g]
-  RESTYLER_NO_NET_NONE   Run restylers without --net=none
+  RESTYLER_NO_NET_NONE
+                         Run restylers without --net=none
+  TERM
   UNRESTRICTED           Run restylers without CPU or
                          Memory restrictions
 ```

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: restyler
-version: 0.4.0.0
+version: 0.4.1.0
 license: MIT
 
 language: GHC2021

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           restyler
-version:        0.4.0.0
+version:        0.4.1.0
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/src/Restyler/CLI.hs
+++ b/src/Restyler/CLI.hs
@@ -28,7 +28,7 @@ main withApp run = do
         pure ExitSuccess
       RestyleSuccessNoDifference -> do
         ExitSuccess <$ logInfo "No differences"
-      RestyleSuccessDifference _ -> do
+      RestyleSuccessDifference -> do
         failOnDifferences <- getFailOnDifferences
 
         if failOnDifferences

--- a/src/Restyler/CLI.hs
+++ b/src/Restyler/CLI.hs
@@ -26,9 +26,9 @@ main withApp run = do
       RestyleSkipped reason -> do
         logInfo $ "Restyle skipped" :# ["reason" .= reason]
         pure ExitSuccess
-      RestyleSuccessNoDifference -> do
+      RestyleNoDifference -> do
         ExitSuccess <$ logInfo "No differences"
-      RestyleSuccessDifference -> do
+      RestyleDifference -> do
         failOnDifferences <- getFailOnDifferences
 
         if failOnDifferences

--- a/src/Restyler/Git.hs
+++ b/src/Restyler/Git.hs
@@ -16,16 +16,8 @@ import Restyler.AnnotatedException
 import System.Process.Typed
 
 class Monad m => MonadGit m where
-  gitPush :: HasCallStack => String -> m ()
-  gitPushForce :: HasCallStack => String -> m ()
   gitDiffNameOnly :: HasCallStack => Maybe String -> m [FilePath]
-  gitFormatPatch :: HasCallStack => Maybe String -> m Text
   gitCommitAll :: HasCallStack => String -> m String
-  gitCheckout :: HasCallStack => String -> m ()
-  gitInit :: HasCallStack => m ()
-  gitRemoteAdd :: HasCallStack => String -> String -> m ()
-  gitFetch :: HasCallStack => String -> String -> m ()
-  gitSwitch :: HasCallStack => String -> m ()
 
 -- | An instance that invokes the real @git@
 newtype ActualGit m a = ActualGit
@@ -45,41 +37,10 @@ instance
   (MonadUnliftIO m, MonadLogger m, MonadReader env m, HasLogger env)
   => MonadGit (ActualGit m)
   where
-  gitPush branch = runGit_ ["push", "origin", branch]
-  gitPushForce branch = runGit_ ["push", "--force", "origin", branch]
   gitDiffNameOnly mRef = readGitLines $ ["diff", "--name-only"] <> maybeToList mRef
-  gitFormatPatch mRef = readGit $ ["format-patch", "--stdout"] <> maybeToList mRef
   gitCommitAll msg = do
     runProcess_ $ proc "git" ["commit", "-a", "--message", msg]
     readGitChomp ["rev-parse", "HEAD"]
-  gitCheckout branch = runGit_ ["checkout", "--no-progress", "-b", branch]
-  gitInit = runGit_ ["init", "--quiet", "."]
-  gitRemoteAdd name url = runGit_ ["remote", "add", name, url]
-  gitFetch name refspec = runGit_ ["fetch", "--quiet", "--depth", "1", name, refspec]
-  gitSwitch branch = runGit_ ["checkout", "--no-progress", branch]
-
-runGit_
-  :: ( MonadUnliftIO m
-     , MonadLogger m
-     , MonadReader env m
-     , HasLogger env
-     , HasCallStack
-     )
-  => [String]
-  -> m ()
-runGit_ args = checkpointCallStack $ do
-  logDebug $ ("exec git " <> unwords (map (sanitizeToken . pack) args)) :# []
-  flushLogger
-  runProcess_ $ proc "git" args
-
--- | Best-effort sanitize of arguments that contain a GitHub token
---
--- If this doesn't work, it's fine. The logging is as DEBUG and there is more
--- robust sanitization wherever these logs will appear (restyled.io or GHA).
-sanitizeToken :: Text -> Text
-sanitizeToken original = fromMaybe original $ do
-  rest <- T.stripPrefix "https://x-access-token:" original
-  pure $ "https://" <> T.drop 1 (T.dropWhile (/= '@') rest)
 
 readGit
   :: ( MonadUnliftIO m
@@ -124,13 +85,5 @@ newtype NullGit m a = NullGit
   deriving newtype (Functor, Applicative, Monad)
 
 instance Monad m => MonadGit (NullGit m) where
-  gitPush _ = pure ()
-  gitPushForce _ = pure ()
   gitDiffNameOnly _ = pure []
-  gitFormatPatch _ = pure ""
   gitCommitAll _ = pure ""
-  gitCheckout _ = pure ()
-  gitInit = pure ()
-  gitRemoteAdd _ _ = pure ()
-  gitFetch _ _ = pure ()
-  gitSwitch _ = pure ()

--- a/src/Restyler/Local.hs
+++ b/src/Restyler/Local.hs
@@ -68,5 +68,5 @@ run pr paths = do
       results <- runRestylers config paths
       pure
         $ if any restylerCommittedChanges results
-          then RestyleSuccessDifference results
+          then RestyleSuccessDifference
           else RestyleSuccessNoDifference

--- a/src/Restyler/Local.hs
+++ b/src/Restyler/Local.hs
@@ -24,25 +24,6 @@ import Restyler.RestyleResult
 import Restyler.Restyler.Run
 import Restyler.RestylerResult
 
--- | A 'PullRequest'-like object designed to never match the state or ignore
--- checks we do here when running against a real PR.
-data NullPullRequest = NullPullRequest
-
-instance HasPullRequestState NullPullRequest where
-  getPullRequestState = const PullRequestOpen
-
-instance HasAuthor NullPullRequest where
-  getAuthor = const "NONE"
-
-instance HasBaseRef NullPullRequest where
-  getBaseRef = const "UNKNOWN"
-
-instance HasHeadSha NullPullRequest where
-  getHeadSha = const "UNKNOWN"
-
-instance HasLabelNames NullPullRequest where
-  getLabelNames = const []
-
 run
   :: ( MonadUnliftIO m
      , MonadLogger m

--- a/src/Restyler/Local/Options.hs
+++ b/src/Restyler/Local/Options.hs
@@ -25,19 +25,25 @@ data Options = Options
   { logSettings :: LogSettingsOption
   , failOnDifferences :: FailOnDifferencesOption
   , hostDirectory :: HostDirectoryOption
+  , imageCleanup :: ImageCleanupOption
+  , manifest :: ManifestOption
   , noCommit :: NoCommitOption
   , restrictions :: Restrictions
   }
   deriving stock (Generic)
   deriving (Semigroup) via (GenericSemigroupMonoid Options)
-  deriving (HasManifestOption) via (NoManifestOption Options)
-  deriving (HasImageCleanupOption) via (NoImageCleanupOption Options)
 
 instance HasFailOnDifferencesOption Options where
   getFailOnDifferencesOption = (.failOnDifferences)
 
 instance HasHostDirectoryOption Options where
   getHostDirectoryOption = (.hostDirectory)
+
+instance HasImageCleanupOption Options where
+  getImageCleanupOption = (.imageCleanup)
+
+instance HasManifestOption Options where
+  getManifestOption = (.manifest)
 
 instance HasNoCommitOption Options where
   getNoCommitOption = (.noCommit)
@@ -49,18 +55,22 @@ envParser :: Env.Parser Env.Error Options
 envParser =
   Options
     <$> envLogSettingsOption
-    <*> envFailOnDifferences
+    <*> envFailOnDifferencesOption
     <*> envHostDirectoryOption
-    <*> envNoCommit
+    <*> envImageCleanupOption
+    <*> envManifestOption
+    <*> envNoCommitOption
     <*> envRestrictions
 
 optParser :: Parser Options
 optParser =
   Options
     <$> optLogSettingsOption
-    <*> optFailOnDifferences
+    <*> optFailOnDifferencesOption
     <*> optHostDirectoryOption
-    <*> optNoCommit
+    <*> optImageCleanupOption
+    <*> optManifestOption
+    <*> optNoCommitOption
     <*> pure mempty -- Restrictions are ENV-only
 
 class HasOptions a where

--- a/src/Restyler/Options/FailOnDifferences.hs
+++ b/src/Restyler/Options/FailOnDifferences.hs
@@ -2,8 +2,8 @@ module Restyler.Options.FailOnDifferences
   ( FailOnDifferencesOption (..)
   , HasFailOnDifferencesOption (..)
   , getFailOnDifferences
-  , envFailOnDifferences
-  , optFailOnDifferences
+  , envFailOnDifferencesOption
+  , optFailOnDifferencesOption
   ) where
 
 import Restyler.Prelude
@@ -23,14 +23,14 @@ getFailOnDifferences
   :: (MonadReader env m, HasFailOnDifferencesOption env) => m Bool
 getFailOnDifferences = asks $ getAny . (.unwrap) . getFailOnDifferencesOption
 
-envFailOnDifferences :: Env.Parser Env.Error FailOnDifferencesOption
-envFailOnDifferences =
+envFailOnDifferencesOption :: Env.Parser Env.Error FailOnDifferencesOption
+envFailOnDifferencesOption =
   FailOnDifferencesOption
     . Any
     <$> Env.switch "FAIL_ON_DIFFERENCES" (Env.help optionHelp)
 
-optFailOnDifferences :: Parser FailOnDifferencesOption
-optFailOnDifferences =
+optFailOnDifferencesOption :: Parser FailOnDifferencesOption
+optFailOnDifferencesOption =
   FailOnDifferencesOption
     . Any
     <$> switch (long "fail-on-differences" <> help optionHelp)

--- a/src/Restyler/Options/Manifest.hs
+++ b/src/Restyler/Options/Manifest.hs
@@ -32,7 +32,14 @@ optManifestOption :: Parser ManifestOption
 optManifestOption =
   ManifestOption
     . Last
-    <$> optional (option str (long "manifest" <> help optionHelp))
+    <$> optional
+      ( option
+          str
+          ( long "manifest"
+              <> metavar "FILE"
+              <> help optionHelp
+          )
+      )
 
 optionHelp :: String
 optionHelp = "Restylers manifest to use"

--- a/src/Restyler/Options/NoCommit.hs
+++ b/src/Restyler/Options/NoCommit.hs
@@ -2,8 +2,8 @@ module Restyler.Options.NoCommit
   ( NoCommitOption (..)
   , HasNoCommitOption (..)
   , getNoCommit
-  , envNoCommit
-  , optNoCommit
+  , envNoCommitOption
+  , optNoCommitOption
   ) where
 
 import Restyler.Prelude
@@ -22,12 +22,12 @@ class HasNoCommitOption a where
 getNoCommit :: (MonadReader env m, HasNoCommitOption env) => m Bool
 getNoCommit = asks $ getAny . (.unwrap) . getNoCommitOption
 
-envNoCommit :: Env.Parser Env.Error NoCommitOption
-envNoCommit =
+envNoCommitOption :: Env.Parser Env.Error NoCommitOption
+envNoCommitOption =
   NoCommitOption . Any <$> Env.switch "NO_COMMIT" (Env.help optionHelp)
 
-optNoCommit :: Parser NoCommitOption
-optNoCommit =
+optNoCommitOption :: Parser NoCommitOption
+optNoCommitOption =
   NoCommitOption . Any <$> switch (long "no-commit" <> help optionHelp)
 
 optionHelp :: String

--- a/src/Restyler/RestyleResult.hs
+++ b/src/Restyler/RestyleResult.hs
@@ -6,12 +6,11 @@ module Restyler.RestyleResult
 import Restyler.Prelude
 
 import Restyler.Ignore
-import Restyler.RestylerResult
 
 data RestyleResult
   = RestyleSkipped RestyleSkipped
   | RestyleSuccessNoDifference
-  | RestyleSuccessDifference [RestylerResult]
+  | RestyleSuccessDifference
 
 data RestyleSkipped
   = RestyleNotEnabled

--- a/src/Restyler/RestyleResult.hs
+++ b/src/Restyler/RestyleResult.hs
@@ -9,8 +9,8 @@ import Restyler.Ignore
 
 data RestyleResult
   = RestyleSkipped RestyleSkipped
-  | RestyleSuccessNoDifference
-  | RestyleSuccessDifference
+  | RestyleNoDifference
+  | RestyleDifference
 
 data RestyleSkipped
   = RestyleNotEnabled

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -12,7 +12,6 @@ module Restyler.Restyler.Run
 
     -- * Exported for testing only
   , runRestyler
-  , runRestyler_
   , withFilteredPaths
   , findFiles
   ) where

--- a/src/Restyler/RestylerResult.hs
+++ b/src/Restyler/RestylerResult.hs
@@ -1,9 +1,6 @@
 module Restyler.RestylerResult
   ( RestylerResult (..)
-  , RestyleOutcome (..)
-  , noPathsRestylerResult
   , getRestylerResult
-  , restylerCommittedChanges
   ) where
 
 import Restyler.Prelude
@@ -14,23 +11,13 @@ import Restyler.Git
 import Restyler.Options.NoCommit
 import Restyler.Restyler
 
-data RestyleOutcome
-  = NoPaths
-  | NoChanges
-  | ChangesCommitted [FilePath] Text
-  deriving stock (Generic)
-  deriving anyclass (ToJSON)
-
 data RestylerResult = RestylerResult
   { restyler :: Restyler
-  , outcome :: RestyleOutcome
+  , restyled :: NonEmpty FilePath
+  , sha :: Maybe String
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON)
-
--- | A @'RestylerResult'@ indicating there were no paths to restyle
-noPathsRestylerResult :: Restyler -> RestylerResult
-noPathsRestylerResult r = RestylerResult r NoPaths
 
 -- | Build a @'RestylerResult'@ based on what @git@ says
 --
@@ -39,33 +26,23 @@ getRestylerResult
   :: (MonadGit m, MonadReader env m, HasNoCommitOption env)
   => Config
   -> Restyler
-  -> m RestylerResult
-getRestylerResult config r = RestylerResult r <$> getRestyleOutcome config r
-
--- | Does this @'RestylerResult'@ indicate changes were comitted?
-restylerCommittedChanges :: RestylerResult -> Bool
-restylerCommittedChanges rr = committedChanges rr.outcome
- where
-  committedChanges (ChangesCommitted _ _) = True
-  committedChanges _ = False
-
-getRestyleOutcome
-  :: (MonadGit m, MonadReader env m, HasNoCommitOption env)
-  => Config
-  -> Restyler
-  -> m RestyleOutcome
-getRestyleOutcome config restyler = do
+  -> m (Maybe RestylerResult)
+getRestylerResult config restyler = do
   noCommit <- getNoCommit
-  changedPaths <- gitDiffNameOnly Nothing
+  mRestyled <- nonEmpty <$> gitDiffNameOnly Nothing
 
-  if null changedPaths
-    then pure NoChanges
-    else do
-      sha <-
-        if noCommit
-          then pure "<commit skipped>"
-          else gitCommitAll commitMessage
-      pure $ ChangesCommitted changedPaths $ pack sha
+  for mRestyled $ \restyled -> do
+    sha <-
+      if noCommit
+        then pure Nothing
+        else Just <$> gitCommitAll commitMessage
+
+    pure
+      $ RestylerResult
+        { restyler
+        , restyled
+        , sha
+        }
  where
   inputs = CommitTemplateInputs {restyler}
   commitMessage = renderCommitTemplate inputs $ cCommitTemplate config

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -25,9 +25,9 @@ spec = withTestApp $ do
               }
           ]
           ["a", "b"]
-          (const pure)
+          (const $ pure . Just)
 
-      filtered `shouldBe` [["a", "b"], ["a"]]
+      filtered `shouldBe` Just (["a", "b"] :| [["a"]])
 
   describe "runRestyler_" $ do
     it "treats non-zero exit codes as RestylerExitFailure"

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -29,13 +29,14 @@ spec = withTestApp $ do
 
       filtered `shouldBe` Just (["a", "b"] :| [["a"]])
 
-  describe "runRestyler_" $ do
+  describe "runRestyler" $ do
     it "treats non-zero exit codes as RestylerExitFailure"
       $ testAppExample
       $ do
         pendingWith "The separate docker-pull process fails first now"
+        config <- loadDefaultConfig
         local (\x -> x {taProcessExitCodes = ExitFailure 99}) $ do
-          runRestyler_ (someRestyler "foo") ["bar"]
+          runRestyler config (someRestyler "foo") ["bar"]
             `shouldThrow` ( ==
                               RestylerExitFailure
                                 (someRestyler "foo")

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -47,6 +47,7 @@ import LoadEnv (loadEnvFrom)
 import Restyler.AnnotatedException
 import Restyler.Config
 import Restyler.Docker
+import Restyler.Git
 import Restyler.Local.Options
 import Restyler.Options.FailOnDifferences
 import Restyler.Options.HostDirectory
@@ -99,6 +100,7 @@ newtype TestAppT a = TestAppT
     , MonadLogger
     , MonadReader TestApp
     )
+  deriving (MonadGit) via (NullGit TestAppT)
   deriving (MonadDocker) via (NullDocker TestAppT)
 
 instance MonadSystem TestAppT where

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -47,7 +47,6 @@ import LoadEnv (loadEnvFrom)
 import Restyler.AnnotatedException
 import Restyler.Config
 import Restyler.Docker
-import Restyler.Git
 import Restyler.Local.Options
 import Restyler.Options.FailOnDifferences
 import Restyler.Options.HostDirectory
@@ -100,7 +99,6 @@ newtype TestAppT a = TestAppT
     , MonadLogger
     , MonadReader TestApp
     )
-  deriving (MonadGit) via (NullGit TestAppT)
   deriving (MonadDocker) via (NullDocker TestAppT)
 
 instance MonadSystem TestAppT where

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -52,6 +52,7 @@ import Restyler.Local.Options
 import Restyler.Options.FailOnDifferences
 import Restyler.Options.HostDirectory
 import Restyler.Options.ImageCleanup
+import Restyler.Options.Manifest
 import Restyler.Options.NoCommit
 import Restyler.Restrictions
 import Restyler.Restyler
@@ -66,14 +67,20 @@ data TestApp = TestApp
   , taFS :: FS
   , taProcessExitCodes :: ExitCode
   }
-  deriving (HasHostDirectoryOption, HasRestrictions) via (ThroughOptions TestApp)
-  deriving (HasImageCleanupOption) via (NoImageCleanupOption TestApp)
+  deriving
+    ( HasHostDirectoryOption
+    , HasRestrictions
+    )
+    via (ThroughOptions TestApp)
 
 instance HasLogger TestApp where
   loggerL = lens taLogger $ \x y -> x {taLogger = y}
 
 instance HasOptions TestApp where
   getOptions = taOptions
+
+instance HasImageCleanupOption TestApp where
+  getImageCleanupOption = const $ ImageCleanupOption $ Any False
 
 instance HasNoCommitOption TestApp where
   getNoCommitOption = const $ NoCommitOption $ Any False
@@ -136,10 +143,12 @@ testOptions :: Options
 testOptions =
   Options
     { logSettings = error "logSettings"
-    , restrictions = fullRestrictions
-    , hostDirectory = toHostDirectoryOption Nothing
-    , noCommit = NoCommitOption $ Any False
     , failOnDifferences = FailOnDifferencesOption $ Any False
+    , hostDirectory = HostDirectoryOption $ Last Nothing
+    , imageCleanup = ImageCleanupOption $ Any False
+    , manifest = ManifestOption $ Last Nothing
+    , noCommit = NoCommitOption $ Any False
+    , restrictions = fullRestrictions
     }
 
 testAppExample :: TestAppT a -> TestAppT a


### PR DESCRIPTION
- **Re-order Local.Options**
- **Implement manifest and image-cleanup options**
- **Fix inconsistent naming**
- **Update --help in README**
- **Remove unused MonadGit members**
- **Remove unused PullRequest features**
- **Stop passing around unused Results**
- **Get rid of TooManyPaths check and exception**
- **Simplify RestylerResult**
- **Stop exporting runRestyler_**
- **Version bump**
