### PR TITLE
Logging, image-cleanup, and exclude-handling fixes

### DIFF
--- a/src/Restyler/Docker.hs
+++ b/src/Restyler/Docker.hs
@@ -10,7 +10,6 @@ module Restyler.Docker
 
 import Restyler.Prelude
 
-import Blammo.Logging.Logger (flushLogger)
 import Data.Text qualified as T
 import Restyler.AnnotatedException
 import System.Process.Typed
@@ -49,8 +48,7 @@ runDocker
   => [String]
   -> m ExitCode
 runDocker args = checkpointCallStack $ do
-  logDebug $ ("exec docker " <> unwords (map pack args)) :# []
-  flushLogger
+  logProc "docker" args
   runProcess $ proc "docker" args
 
 runDocker_
@@ -58,8 +56,7 @@ runDocker_
   => [String]
   -> m ()
 runDocker_ args = checkpointCallStack $ do
-  logDebug $ ("exec docker " <> unwords (map pack args)) :# []
-  flushLogger
+  logProc "docker" args
   runProcess_ $ proc "docker" args
 
 runDockerStdout
@@ -67,8 +64,7 @@ runDockerStdout
   => [String]
   -> m (ExitCode, Text)
 runDockerStdout args = checkpointCallStack $ do
-  logDebug $ ("exec docker " <> unwords (map pack args)) :# []
-  flushLogger
+  logProc "docker" args
   second (fixNewline . decodeUtf8) <$> readProcessStdout (proc "docker" args)
 
 fixNewline :: Text -> Text

--- a/src/Restyler/Prelude.hs
+++ b/src/Restyler/Prelude.hs
@@ -24,6 +24,7 @@ import UnliftIO.Concurrent as X (threadDelay)
 import UnliftIO.Exception as X (finally)
 import UnliftIO.Temporary as X (withSystemTempDirectory)
 
+import Blammo.Logging.Logger (flushLogger)
 import Data.Aeson (Key)
 import Data.Aeson.KeyMap (KeyMap)
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -31,6 +32,20 @@ import Data.List (minimum, minimumBy, (!!))
 
 logTrace :: (MonadLogger m, HasCallStack) => Message -> m ()
 logTrace = logOther $ LevelOther "trace"
+
+logProc
+  :: ( MonadIO m
+     , MonadLogger m
+     , MonadReader env m
+     , HasLogger env
+     , HasCallStack
+     )
+  => String
+  -> [String]
+  -> m ()
+logProc cmd args = do
+  logDebug $ unwords (map pack $ "exec" : cmd : args) :# []
+  flushLogger
 
 minimumMaybe :: Ord a => [a] -> Maybe a
 minimumMaybe = \case

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -139,17 +139,18 @@ withFilteredPaths restylers paths run = do
         included = includePath includes path
 
       logTrace
-        $ "Matching paths"
+        $ "Matching path"
         :# [ "name" .= rName r
            , "path" .= path
            , "matched" .= matched
            , "includes" .= includes
            , "included" .= included
            , "interpreter" .= mInterpreter
-           -- , "filtered" .= filtered
            ]
 
       pure $ if included then Just path else Nothing
+
+    logDebug $ "Matched paths" :# ["name" .= rName r, "filtered" .= filtered]
 
     run r filtered
 

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -104,8 +104,20 @@ runRestylers
   => Config
   -> [FilePath]
   -> m (Maybe (NonEmpty RestylerResult))
-runRestylers config@Config {..} allPaths = do
-  paths <- findFiles $ filter included allPaths
+runRestylers config@Config {..} argPaths = do
+  let allPaths = filter included argPaths
+  expPaths <- findFiles allPaths
+  let paths = filter included expPaths
+
+  logDebug
+    $ "Paths"
+    :# [ "pathsGiven" .= argPaths
+       , "pathsGivenIncluded" .= allPaths
+       , "pathsExpanded" .= expPaths
+       , "pathsExpandedIncluded" .= paths
+       , "exclude" .= cExclude
+       ]
+
   for_ cRemoteFiles $ \rf -> downloadFile rf.url rf.path
   withFilteredPaths restylers paths $ runRestyler config
  where


### PR DESCRIPTION
### [Centralize process logging, fix missing git log](https://github.com/restyled-io/restyler/pull/261/commits/d7c93b58630d046c45412bb6e3d3e4ce95a1ad23)
[d7c93b5](https://github.com/restyled-io/restyler/pull/261/commits/d7c93b58630d046c45412bb6e3d3e4ce95a1ad23)

### [Fix image-cleanup in one-at-a-time case](https://github.com/restyled-io/restyler/pull/261/commits/8a1f129a9b93b7a69f39aa73120e014cae68a976)
[8a1f129](https://github.com/restyled-io/restyler/pull/261/commits/8a1f129a9b93b7a69f39aa73120e014cae68a976)

Before we would clean up images as part of run, so if we were running
the same restyler multiple times (once per file) we would remove and
then immediately re-pull (as part of `run`) on each file.

This refactor moves it out to a more reasonable place. Along with the
rename, the code looks to more clearly represent the 3-step process of
pull, run, remove.

### [Tweak log levels in filtering logging](https://github.com/restyled-io/restyler/pull/261/commits/2e1fd83b434d891fc8403342264e9fd7fb7609ad)
[2e1fd83](https://github.com/restyled-io/restyler/pull/261/commits/2e1fd83b434d891fc8403342264e9fd7fb7609ad)

New best practice: when "debug" logging a loop, log outside the loop at
`DEBUG` and on each iteration of the loop at `TRACE`. This gives you
useful information without overwhelming, but still makes the
"overwhelming" information available when necessary.

### [Fix exclude handling with explicit arguments](https://github.com/restyled-io/restyler/pull/261/commits/658ab3dbc11626f7fba09a4da9566505f9f917e5)
[658ab3d](https://github.com/restyled-io/restyler/pull/261/commits/658ab3dbc11626f7fba09a4da9566505f9f917e5)

This logic would only apply our excludes to the arguments given, not the
files post-expanded. This means if you call `restyle .` it effectively
ignores excludes.

This was mostly fine as usage on a PR will always pass fully expanded
paths, but breaks locally, particularly in our integration tests where a
`.git` directory would be picked up by shebang.

The fix is to apply excludes after expansion, but we can also apply them
before as an optimization (no use expanding if excludes happen to hit at
that level already).