### PR TITLE
Run Restyled workflow on closed PR actions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -2,6 +2,11 @@ name: Restyled
 
 on:
   pull_request:
+    types:
+      - opened
+      - closed
+      - reopened
+      - synchronize
 
 jobs:
   restyled:


### PR DESCRIPTION
When this workflow runs on a `closed` PR action:

1. Restyler skips due to the PR being closed, which means
2. There is no diff, which means
3. `create-pull-request-action` deletes the restyled branch, which means
4. GitHub closes the Restyled PR

So simply including this action type brings back the "clean up on close"
behavior we want.

The only annoying thing is once you add this list, you now have to
re-include the default non-`closed` actions we want to run on, which,
thankfully, aren't that many.
