### PR TITLE
Don't run Restyled on merged PRs (only closed)

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   restyled:
+    if: ${{ github.event.pull_request.merged != true }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
If merged, the head branch would be automatically deleted and our
checkout will fail. This means that only closed (abandoned) PRs will
clean up any open Restyled PR. If you merge without fixing style, the
Restyle PR will be left.
