### PR TITLE
Improvements for local and test usage

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: restyler
-version: 0.5.0.0
+version: 0.5.0.1
 license: AGPL-3
 
 language: GHC2021

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           restyler
-version:        0.5.0.0
+version:        0.5.0.1
 license:        AGPL-3
 build-type:     Simple
 

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -130,8 +130,8 @@ runRestylers config@Config {..} argPaths = do
     $ "Paths"
     :# [ "pathsGiven" .= argPaths
        , "pathsGivenIncluded" .= allPaths
-       , "pathsExpanded" .= expPaths
-       , "pathsExpandedIncluded" .= paths
+       , "pathsExpanded" .= truncatePaths 50 expPaths
+       , "pathsExpandedIncluded" .= truncatePaths 50 paths
        , "exclude" .= cExclude
        ]
 
@@ -423,3 +423,10 @@ findFiles = fmap concat . traverse go
         guardM $ lift $ doesFileExist parent
         guardM $ lift $ not <$> pathIsSymbolicLink parent
         pure parent
+
+truncatePaths :: Int -> [FilePath] -> [String]
+truncatePaths n ps
+  | len > n = take n ps <> ["And " <> show (len - n) <> " more..."]
+  | otherwise = ps
+ where
+  len = length ps

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -51,6 +51,7 @@ import Restyler.Restyler
 import Restyler.RestylerResult
 import Restyler.Wiki qualified as Wiki
 import System.FilePath ((</>))
+import System.FilePath qualified as FilePath
 
 data RestylerPullFailure = RestylerPullFailure Restyler Int
   deriving stock (Show, Eq)
@@ -122,7 +123,7 @@ runRestylers
   -> [FilePath]
   -> m (Maybe (NonEmpty RestylerResult))
 runRestylers config@Config {..} argPaths = do
-  let allPaths = filter included argPaths
+  let allPaths = filter included $ map FilePath.normalise argPaths
   expPaths <- findFiles allPaths
   let paths = filter included expPaths
 
@@ -422,7 +423,7 @@ findFiles = fmap concat . traverse go
       else fmap maybeToList $ runMaybeT $ do
         guardM $ lift $ doesFileExist parent
         guardM $ lift $ not <$> pathIsSymbolicLink parent
-        pure parent
+        pure $ FilePath.normalise parent
 
 truncatePaths :: Int -> [FilePath] -> [String]
 truncatePaths n ps

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -419,11 +419,14 @@ findFiles = fmap concat . traverse go
     if isDirectory
       then do
         files <- listDirectory parent
-        findFiles $ map (parent </>) files
+        findFiles $ map (parent </>) $ filter (not . isHidden) files
       else fmap maybeToList $ runMaybeT $ do
         guardM $ lift $ doesFileExist parent
         guardM $ lift $ not <$> pathIsSymbolicLink parent
         pure $ FilePath.normalise parent
+
+isHidden :: FilePath -> Bool
+isHidden path = "." `isPrefixOf` path && path `notElem` [".", ".."]
 
 truncatePaths :: Int -> [FilePath] -> [String]
 truncatePaths n ps

--- a/test/Restyler/Restyler/RunSpec.hs
+++ b/test/Restyler/Restyler/RunSpec.hs
@@ -68,3 +68,26 @@ spec = withTestApp $ do
       createFileLink "/foo/bat" "/foo/bar"
 
       findFiles ["foo"] `shouldReturn` ["foo/bar"]
+
+    it "doesn't include hidden files" $ testAppExample $ do
+      writeFile "/foo/bar/baz/bat" ""
+      writeFile "/foo/bar/baz/.quix" ""
+      writeFile "/foo/bar/baz/.foo/bar" ""
+      writeFile "/foo/bat/baz" ""
+      writeFile "/foo/foo" ""
+      writeFile "/foo/xxx" ""
+      setCurrentDirectory "/foo"
+
+      findFiles ["bar/baz", "bat", "xxx", "zzz"]
+        `shouldReturn` ["bar/baz/bat", "bat/baz", "xxx"]
+
+    it "includes hidden files given explicitly" $ testAppExample $ do
+      writeFile "/foo/.bar/baz/bat" ""
+      writeFile "/foo/.bar/baz/quix" ""
+      writeFile "/foo/bat/baz" ""
+      writeFile "/foo/foo" ""
+      writeFile "/foo/xxx" ""
+      setCurrentDirectory "/foo"
+
+      findFiles [".bar/baz", "bat", "xxx", "zzz"]
+        `shouldReturn` [".bar/baz/bat", ".bar/baz/quix", "bat/baz", "xxx"]


### PR DESCRIPTION
Running something like `restyle .` was behaving oddly, including lots of
`.git` and `node_modules`, which I expected to be excluded.

This was due to a confluence of issues that _don't_ occur when the list of
changed files in a PR are the arguments passed -- which is why I'd not
encountered the error before.

Basically, expansion of the `.` directory:

1. Made everything come out prefixed by `./...`, which causes excludes not to match
2. Expanded nested hidden directories and included nested hidden files, which was unexpected

We still have some bugs in our excludes, which we inherit from
`System.FilePath.Glob`'s implementation of `**/`, but fixing issue (2) there mostly
avoids them.

---

### [Truncate paths in debug messages](https://github.com/restyled-io/restyler/pull/279/commits/1696229e9c306583580a6592c297a9597706bceb)
[1696229](https://github.com/restyled-io/restyler/pull/279/commits/1696229e9c306583580a6592c297a9597706bceb)

### [Normalise paths before processing excludes](https://github.com/restyled-io/restyler/pull/279/commits/94f0268ec5986fdce6208cfdb01d93187039ddfd)
[94f0268](https://github.com/restyled-io/restyler/pull/279/commits/94f0268ec5986fdce6208cfdb01d93187039ddfd)

### [Avoid hidden files in expanding arguments](https://github.com/restyled-io/restyler/pull/279/commits/25c2510ba4003b7cd6a1c96cf8c412f3c8d3172b)
[25c2510](https://github.com/restyled-io/restyler/pull/279/commits/25c2510ba4003b7cd6a1c96cf8c412f3c8d3172b)

This doesn't change anything when paths are given explicitly (such as in
the list of changed files on PRs), but when directories are given in
local or test usage, and we are expanding them, we now exclude hidden
files. I think this makes the most sense: match the behavior of a
recursive `ls`.

### [Version bump](https://github.com/restyled-io/restyler/pull/279/commits/2a6ce9c89f281912a9dd49a56ec9a6ca39de39c1)
[2a6ce9c](https://github.com/restyled-io/restyler/pull/279/commits/2a6ce9c89f281912a9dd49a56ec9a6ca39de39c1)