### PR TITLE
Ignore git-clean failures

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: restyler
-version: 0.5.2.0
+version: 0.5.2.1
 license: AGPL-3
 
 language: GHC2021

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           restyler
-version:        0.5.2.0
+version:        0.5.2.1
 license:        AGPL-3
 build-type:     Simple
 

--- a/src/Restyler/Monad/Git.hs
+++ b/src/Restyler/Monad/Git.hs
@@ -52,7 +52,12 @@ instance
   gitCommit msg paths = do
     runGit_ $ ["commit", "--message", msg, "--"] <> toList paths
     readGitChomp ["rev-parse", "HEAD"]
-  gitClean = runGit_ ["clean", "-d", "--force"]
+  gitClean = do
+    ec <- runGitExitCode ["clean", "-d", "--force"]
+    when (ec /= ExitSuccess)
+      $ logWarn
+      $ "git clean not successful"
+      :# ["exitCode" .= show @Text ec]
   gitResetHard ref = runGit_ ["reset", "--hard", ref]
 
 runGit_


### PR DESCRIPTION
Some restylers create files that we do not have permission to clean up.
I might've expected that to always be the case, since they run in a
container as `root`, but many restylers create files we can and do clean
up. Attempting it and ignoring permissions errors seems fine; it was
best-effort anyway.