### PR TITLE
Reverse configPaths order

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: restyler
-version: 0.6.0.0
+version: 0.6.0.1
 license: AGPL-3
 
 language: GHC2021

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           restyler
-version:        0.6.0.0
+version:        0.6.0.1
 license:        AGPL-3
 build-type:     Simple
 

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -68,10 +68,10 @@ parseConfig = runParser Pkg.version "Restyle local files" $ configParser configP
 
 configPaths :: [FilePath]
 configPaths =
-  [ ".github/restyled.yml"
-  , ".github/restyled.yaml"
+  [ ".restyled.yaml"
   , ".restyled.yml"
-  , ".restyled.yaml"
+  , ".github/restyled.yaml"
+  , ".github/restyled.yml"
   ]
 
 configParser :: [FilePath] -> Parser Config


### PR DESCRIPTION
When this was written, we were loading merged configs, so we wanted them
apply with "last-wins". Now that we're loading the first found, we need
the order to be reversed.
