### PR TITLE
Filter in versions instead of filtering out RCs

### DIFF
--- a/install
+++ b/install
@@ -52,7 +52,7 @@ if [ -z "$tag" ]; then
     -sSf https://api.github.com/repos/restyled-io/restyler/releases |
     grep -o '"tag_name": ".*"' |
     sed 's/^.*: "//; s/"$//' |
-    grep -v -- '-rc$' |
+    grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+$' |
     head -n 1)
 fi
 


### PR DESCRIPTION
Since we're not using a proper JSON parser, we can't easily filter by
prerelease or draft attributes, instead we need to filter on the tag
values themselves. Filtering *out* `-rc$` was effective when those were
the only kind of prereleases we made, but as we experiment with Semantic
Release, this changes. It's better to use positive filtering anyway.
