### PR TITLE
fix: correct docker-pull retry logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - id: stack
         uses: freckle/stack-action@v5
-      - uses: freckle/weeder-action@v2
-        with:
-          ghc-version: ${{ steps.stack.outputs.compiler-version }}
       - uses: extractions/setup-just@v2
       - run: just dist
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This was originally written against exceptions, but we're calling a
process and using the exit code to throw later, so it was never raising
any exceptions at the point of our retry logic. Instead we should move
it outside and use the non-exception `retrying` based on that exit code.