### PR TITLE
chore(release): fix configuration format

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -3,10 +3,9 @@ tagFormat: "v0.${version}" # PVP prefixed
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/github":
-      assets:
-        - path: "*-binaries/restyler-*.tar.gz"
-      successComment: false
+  - - "@semantic-release/github"
+    - assets: "*-binaries/restyler-*.tar.gz"
+      successCommentCondition: false
 
 branches:
   - main


### PR DESCRIPTION
Apparently this needs to be an "options array", even in yaml. Best part
is it is silently ignored when it's not properly-formatted. loljs.

Also replaced `successComment` with `successCommentCondition` because
the former is deprecated.