### PR TITLE
chore: parse GITHUB_ACTIONS with OptEnvConf too

### DIFF
--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -81,5 +81,8 @@ withApp :: (App -> IO a) -> IO a
 withApp f = do
   config <- parseConfig
   logSettings <- getLogSettings config.logSettings
-  setReformat <- getSetReformat
-  withLogger logSettings $ f . App config . setReformat
+
+  withLogger logSettings
+    $ f
+    . App config
+    . getSetReformat config.githubActions

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -19,7 +19,7 @@ module Restyler.Config
   , module X
   ) where
 
-import Restyler.Prelude
+import Restyler.Prelude hiding (Reader)
 
 import OptEnvConf
 import Paths_restyler qualified as Pkg
@@ -59,6 +59,7 @@ data Config = Config
   , noCommit :: Bool
   , noClean :: Bool
   , logSettings :: LogSettingsOption
+  , githubActions :: Bool
   , pullRequestJson :: Maybe (Path Abs File)
   , paths :: NonEmpty FilePath
   }
@@ -94,6 +95,14 @@ configParser sources =
     noCommit <- subConfig_ "git" noCommitParser
     noClean <- subConfig_ "git" noCleanParser
     logSettings <- subConfig_ "logging" logSettingsOptionParser
+    githubActions <-
+      setting
+        [ env "GITHUB_ACTIONS"
+        , help "The value \"true\" if running on GitHub Actions"
+        , reader $ boolReader (== "true")
+        , metavar "true"
+        , value False
+        ]
     pullRequestJson <-
       optional
         $ filePathSetting
@@ -117,3 +126,6 @@ configParser sources =
 -- And mark it 'hidden' so it doesn't appear in docs.
 hiddenPath :: FilePath -> Parser (Path Abs File)
 hiddenPath x = filePathSetting [value x, hidden]
+
+boolReader :: (String -> Bool) -> Reader Bool
+boolReader p = maybeReader $ Just . p

--- a/src/Restyler/LogFormat.hs
+++ b/src/Restyler/LogFormat.hs
@@ -24,12 +24,9 @@ import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text qualified as T
 
-getSetReformat :: MonadIO m => m (Logger -> Logger)
-getSetReformat = do
-  isGHA <- (== Just "true") <$> lookupEnv "GITHUB_ACTIONS"
-
-  pure
-    $ setLoggerReformat
+getSetReformat :: Bool -> (Logger -> Logger)
+getSetReformat isGHA = do
+  setLoggerReformat
     $ if isGHA
       then reformatLoggedMessage gray
       else reformatLoggedMessage dim


### PR DESCRIPTION
Might as well centralize it. If nothing else, it'll appear in the
man-page, which is useful since it does affect behavior.
