### PR TITLE
fix: match hidden files in our include globs

### DIFF
--- a/src/Restyler/Config/Include.hs
+++ b/src/Restyler/Config/Include.hs
@@ -16,7 +16,14 @@ import Restyler.Prelude
 
 import Autodocodec
 import Data.Aeson (FromJSON, ToJSON)
-import System.FilePath.Glob (Pattern, compile, decompile, match)
+import System.FilePath.Glob
+  ( MatchOptions (..)
+  , Pattern
+  , compile
+  , decompile
+  , matchDefault
+  , matchWith
+  )
 
 data Include
   = -- | @**\/*.hs@
@@ -60,3 +67,6 @@ includePath is fp = foldl' go False is
   go :: Bool -> Include -> Bool
   go b (Include p) = b || p `match` fp
   go b (Negated p) = b && not (p `match` fp)
+
+match :: Pattern -> FilePath -> Bool
+match = matchWith $ matchDefault {matchDotsImplicitly = True}

--- a/test/Restyler/Config/IncludeSpec.hs
+++ b/test/Restyler/Config/IncludeSpec.hs
@@ -41,15 +41,16 @@ spec = do
       includePath includes "foo/bar.py" `shouldBe` True
       includePath includes "foo/bar.pyc" `shouldBe` False
 
-    it "matches hidden files, if you know how" $ do
+    it "matches hidden files (matchDotsImplicitly)" $ do
       let includes =
             [ Include "**/*.json"
-            , Include ".**/*.json"
-            , Include ".**/.*.json"
-            , Include "**/.*.json"
+            , Include "**/*.yml"
+            , Include "**/*.yaml"
             ]
 
       includePath includes "foo/bar.json" `shouldBe` True
       includePath includes ".foo/bar.json" `shouldBe` True
       includePath includes "foo/.bar.json" `shouldBe` True
       includePath includes ".foo/.bar.json" `shouldBe` True
+      includePath includes ".forgejo/workflows/restyled.yml" `shouldBe` True
+      includePath includes ".restyled.yaml" `shouldBe` True


### PR DESCRIPTION
The default behavior of `Glob:match` is for `**` not to match hidden
files (names beginning with `.`).

As a consequence, a pattern like `**/*.yaml` won't match files like
`.restyled.yaml` or `.github/workflows/x.yaml`.

This makes sense for emulating a shell expansion, where hidden files
should generally remain hidden. However, when we are matching against a
list of changed files in a PR to restyle, we'd expect such an "all yaml
files" glob to still match any changed files in the PR ending in
`.yaml`, even when they are "hidden".

This change flips `matchDotsImplicitly` so that hidden files are
included and such examples will work as expected.

NOTE: I'm only changing the use of `Glob:match` in our `include`
processing. I'm not (yet) changing our `Config.Glob` behavior, which is
used to match labels, owners, and branch names. I may in the future, but
such items beginning with a `.` seems rare.