### PR TITLE
feat: add copy_files configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       # update version in package.yaml, so the --version option works correctly
-      - run: |
+      - if: ${{ steps.release.outputs.new_release_published == 'true' }}
+        run: |
           new_version=$EPOCH.$MAJOR.$MINOR.$PATCH
           yq -i ".version = \"$new_version\"" package.yaml
         env:

--- a/restyler.cabal
+++ b/restyler.cabal
@@ -18,6 +18,7 @@ library
       Restyler.Config
       Restyler.Config.AutoEnable
       Restyler.Config.CommitTemplate
+      Restyler.Config.CopyFiles
       Restyler.Config.DryRun
       Restyler.Config.Enabled
       Restyler.Config.Exclude

--- a/src/Restyler/App.hs
+++ b/src/Restyler/App.hs
@@ -57,6 +57,7 @@ data App = App
 
 {- FOURMOLU_DISABLE -}
 instance HasCommitTemplate App where getCommitTemplate = (.config.commitTemplate)
+instance HasCopyFiles App where getCopyFiles = (.config.copyFiles)
 instance HasDryRun App where getDryRun = (.config.dryRun)
 instance HasEnabled App where getEnabled = (.config.enabled)
 instance HasExclude App where getExclude = (.config.exclude)

--- a/src/Restyler/Config.hs
+++ b/src/Restyler/Config.hs
@@ -24,6 +24,7 @@ import Restyler.Prelude hiding (Reader)
 import OptEnvConf
 import Paths_restyler qualified as Pkg
 import Restyler.Config.CommitTemplate as X
+import Restyler.Config.CopyFiles as X
 import Restyler.Config.DryRun as X
 import Restyler.Config.Enabled as X
 import Restyler.Config.Exclude as X
@@ -51,6 +52,7 @@ data Config = Config
   , restylerOverrides :: [RestylerOverride]
   , ignores :: Ignores
   , remoteFiles :: [RemoteFile]
+  , copyFiles :: CopyFiles
   , imageCleanup :: Bool
   , noPull :: Bool
   , restrictions :: Restrictions
@@ -86,6 +88,7 @@ configParser sources =
     exclude <- excludeParser
     ignores <- ignoresParser
     remoteFiles <- remoteFilesParser
+    copyFiles <- copyFilesParser
     imageCleanup <- subConfig_ "docker" imageCleanupParser
     noPull <- subConfig_ "docker" noPullParser
     restrictions <- subConfig_ "docker" $ subAll "restyler" restrictionsParser

--- a/src/Restyler/Config/CopyFiles.hs
+++ b/src/Restyler/Config/CopyFiles.hs
@@ -17,7 +17,6 @@ import Restyler.Prelude
 
 import Autodocodec hiding ((.=))
 import OptEnvConf hiding (env)
-import Path ((</>))
 import Restyler.CodeVolume
 import Restyler.Config.Glob
 import Restyler.Config.RemoteFile
@@ -110,9 +109,6 @@ copyCodeFiles remoteFiles paths vol = \case
     -- docker cp . container:/path
     dockerCp "." $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap
 
-  dockerCpAll = traverse_ $ \p -> do
-    -- docker cp foo/bar.x container:/path/foo/bar.x
-    dockerCp (toFilePath p)
-      $ vol.container.unwrap
-      <> ":"
-      <> toFilePath (vol.path.unwrap </> p)
+  dockerCpAll ps =
+    -- tar -cf - ps | docker cp - container:/path
+    dockerCpTar ps $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap

--- a/src/Restyler/Config/CopyFiles.hs
+++ b/src/Restyler/Config/CopyFiles.hs
@@ -1,0 +1,118 @@
+-- |
+--
+-- Module      : Restyler.Config.CopyFiles
+-- Copyright   : (c) 2025 Patrick Brisbin
+-- License     : AGPL-3
+-- Maintainer  : pbrisbin@gmail.com
+-- Stability   : experimental
+-- Portability : POSIX
+module Restyler.Config.CopyFiles
+  ( HasCopyFiles (..)
+  , CopyFiles (..)
+  , copyFilesParser
+  , copyCodeFiles
+  ) where
+
+import Restyler.Prelude
+
+import Autodocodec hiding ((.=))
+import OptEnvConf hiding (env)
+import Path ((</>))
+import Restyler.CodeVolume
+import Restyler.Config.Glob
+import Restyler.Config.RemoteFile
+import Restyler.Monad.Directory
+import Restyler.Monad.Docker
+
+class HasCopyFiles env where
+  getCopyFiles :: env -> CopyFiles
+
+data CopyFiles
+  = CopyAll
+  | CopyNone
+  | CopyOnly (NonEmpty (Glob FilePath))
+  deriving stock (Eq, Show)
+
+instance HasCodec CopyFiles where
+  codec = dimapCodec toCopyFiles fromCopyFiles $ maybeCodec codec
+
+toCopyFiles :: Maybe [Glob FilePath] -> CopyFiles
+toCopyFiles = \case
+  Nothing -> CopyAll
+  Just gs -> maybe CopyNone CopyOnly $ nonEmpty gs
+
+fromCopyFiles :: CopyFiles -> Maybe [Glob FilePath]
+fromCopyFiles = \case
+  CopyAll -> Nothing
+  CopyNone -> Just []
+  CopyOnly negs -> Just $ toList negs
+
+copyFilesParser :: Parser CopyFiles
+copyFilesParser =
+  setting
+    [ help
+        $ unpack
+        $ unlines
+          [ "Files to include into restyling context"
+          ]
+    , example
+        $ unpack
+        $ unlines
+          [ "# copy the entire current directory (default)"
+          , "copy_files: null"
+          ]
+    , example
+        $ unpack
+        $ unlines
+          [ "# copy only the files being restyled"
+          , "copy_files: []"
+          ]
+    , example
+        $ unpack
+        $ unlines
+          [ "# copy only the files being restyled and an explicit list"
+          , "copy_files:"
+          , "  - *.cabal"
+          , "  - .prettierrc"
+          ]
+    , conf "copy_files"
+    , value CopyAll
+    ]
+
+copyCodeFiles
+  :: (MonadDirectory m, MonadDocker m, MonadLogger m)
+  => [RemoteFile]
+  -- ^ Downloaded remote files
+  --
+  -- Presumably you'd want them in the context, otherwise why download them?
+  -> [Path Rel File]
+  -- ^ Files to restyle
+  --
+  -- These must also always be in context.
+  -> CodeVolume
+  -> CopyFiles
+  -> m ()
+copyCodeFiles remoteFiles paths vol = \case
+  CopyAll -> do
+    logDebug "Copying all of . into code volume"
+    dockerCpDot
+  CopyNone -> do
+    logDebug "Copying no extra paths into code volume"
+    dockerCpAll alwaysPaths
+  CopyOnly gs -> do
+    logDebug $ "Copying explicit paths into code volume" :# ["globs" .= gs]
+    ps <- globAnyInCurrentDirectory $ toList gs
+    dockerCpAll $ alwaysPaths <> ps
+ where
+  alwaysPaths = map (.path) remoteFiles <> paths
+
+  dockerCpDot = do
+    -- docker cp . container:/path
+    dockerCp "." $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap
+
+  dockerCpAll = traverse_ $ \p -> do
+    -- docker cp foo/bar.x container:/path/foo/bar.x
+    dockerCp (toFilePath p)
+      $ vol.container.unwrap
+      <> ":"
+      <> toFilePath (vol.path.unwrap </> p)

--- a/src/Restyler/Ignore.hs
+++ b/src/Restyler/Ignore.hs
@@ -38,5 +38,5 @@ getIgnoredReason i author branch labels =
   asum
     [ IgnoredByAuthor author <$ guard (i.byAuthor `matchAny` [author])
     , IgnoredByBranch branch <$ guard (i.byBranch `matchAny` [branch])
-    , IgnoredByLabels <$> i.byLabels `matchFirst` labels
+    , IgnoredByLabels <$> i.byLabels `globFirst` labels
     ]

--- a/src/Restyler/Monad/Docker.hs
+++ b/src/Restyler/Monad/Docker.hs
@@ -56,7 +56,7 @@ instance
   dockerRun args = runDocker $ ["run"] <> args
   dockerRunStdout args = runDockerStdout $ ["run"] <> args
   dockerImageRm image = runDocker_ ["image", "rm", "--force", image]
-  dockerVolumeCreate name = runDocker_ ["volume", "create", "--quiet", name]
+  dockerVolumeCreate name = runDocker_ ["volume", "create", name]
   dockerVolumeRm name = runDocker_ ["volume", "rm", name]
   dockerCp src dst = runDocker_ ["cp", "--quiet", src, dst]
   dockerRm name = runDocker_ ["rm", name]

--- a/src/Restyler/Restyle.hs
+++ b/src/Restyler/Restyle.hs
@@ -33,6 +33,7 @@ run
      , HasBaseRef pr
      , HasCallStack
      , HasCommitTemplate env
+     , HasCopyFiles env
      , HasDryRun env
      , HasEnabled env
      , HasExclude env

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -138,8 +138,7 @@ runRestylers argPaths = do
 
   restylers <- getEnabledRestylers
   mResults <- withCodeVolume $ \vol -> do
-    copyFiles <- asks getCopyFiles
-    copyCodeFiles remoteFiles paths vol copyFiles
+    copyCodeFiles remoteFiles paths vol
     withFilteredPaths restylers paths $ runRestyler vol
   mResetTo <- join <$> traverse checkForNoop mResults
 

--- a/src/Restyler/Restyler/Run.hs
+++ b/src/Restyler/Restyler/Run.hs
@@ -126,11 +126,6 @@ runRestylers argPaths = do
   expPaths <- expandSomePaths argPaths
   paths <- removeExcluded expPaths
 
-  remoteFiles <- asks getRemoteFiles
-  for_ remoteFiles $ \rf -> downloadFile rf.url rf.path
-
-  copyFiles <- asks getCopyFiles
-
   logDebug
     $ "Paths"
     :# [ "pathsGiven" .= argPaths
@@ -138,8 +133,12 @@ runRestylers argPaths = do
        , "pathsExpandedIncluded" .= truncateList toFilePath 50 paths
        ]
 
+  remoteFiles <- asks getRemoteFiles
+  for_ remoteFiles $ \rf -> downloadFile rf.url rf.path
+
   restylers <- getEnabledRestylers
   mResults <- withCodeVolume $ \vol -> do
+    copyFiles <- asks getCopyFiles
     copyCodeFiles remoteFiles paths vol copyFiles
     withFilteredPaths restylers paths $ runRestyler vol
   mResetTo <- join <$> traverse checkForNoop mResults


### PR DESCRIPTION
### [feat: add copy_files configuration](https://github.com/restyled-io/restyler/pull/316/commits/135cf6b13ac65bd949b415af645e3175675a81f1) 
[135cf6b](https://github.com/restyled-io/restyler/pull/316/commits/135cf6b13ac65bd949b415af645e3175675a81f1)
`copy_files` can be used to avoid copying the entire current directory
into the "code volume" where the restyling occurs.

A value of `null` means to copy "all", the current behavior. An empty
list means to copy nothing other than any remote files that were
downloaded and the files to be restyled. And an explicit list of globs
means to only copy those that match the globs (in addition to the remote
files and paths to restyle).

This can address problems docker has with copying a very large
directory.

### [fix: use tar to copy paths into code volume](https://github.com/restyled-io/restyler/pull/316/commits/c4f33920f8ee1697492825f2e9ba2f3bf9518424) 
[c4f3392](https://github.com/restyled-io/restyler/pull/316/commits/c4f33920f8ee1697492825f2e9ba2f3bf9518424)
A simple `docker cp x/y` will fail because `x` doesn't exist. The
documentation is vague, but it appears we need to pre-create parents in
order to copy nested paths.

To do that would require starting/running the container, which we don't
have reason to do yet. To avoid it, we can switch to using a tar archive
as input to `docker cp -`. This will create create any parents as
necessary.