### PR TITLE
fix: unique list of paths to tar-docker-cp

### DIFF
--- a/src/Restyler/Config/CopyFiles.hs
+++ b/src/Restyler/Config/CopyFiles.hs
@@ -16,7 +16,6 @@ module Restyler.Config.CopyFiles
 import Restyler.Prelude
 
 import Autodocodec hiding ((.=))
-import Data.List (nub)
 import OptEnvConf hiding (env)
 import Restyler.CodeVolume
 import Restyler.Config.Glob
@@ -117,9 +116,4 @@ copyCodeFiles remoteFiles paths vol = do
 
   dockerCpAll ps =
     -- tar -cf - ps | docker cp - container:/path
-    --
-    -- Ensure ps doesn't contain duplicates, otherwise you'll get an obscure
-    -- error from docker-cp, that it can't find /data.
-    --
-    -- https://github.com/restyled-io/actions/issues/391
-    dockerCpTar (nub ps) $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap
+    dockerCpTar ps $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap

--- a/src/Restyler/Config/CopyFiles.hs
+++ b/src/Restyler/Config/CopyFiles.hs
@@ -16,6 +16,7 @@ module Restyler.Config.CopyFiles
 import Restyler.Prelude
 
 import Autodocodec hiding ((.=))
+import Data.List (nub)
 import OptEnvConf hiding (env)
 import Restyler.CodeVolume
 import Restyler.Config.Glob
@@ -116,4 +117,9 @@ copyCodeFiles remoteFiles paths vol = do
 
   dockerCpAll ps =
     -- tar -cf - ps | docker cp - container:/path
-    dockerCpTar ps $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap
+    --
+    -- Ensure ps doesn't contain duplicates, otherwise you'll get an obscure
+    -- error from docker-cp, that it can't find /data.
+    --
+    -- https://github.com/restyled-io/actions/issues/391
+    dockerCpTar (nub ps) $ vol.container.unwrap <> ":" <> toFilePath vol.path.unwrap

--- a/src/Restyler/Monad/Docker.hs
+++ b/src/Restyler/Monad/Docker.hs
@@ -18,6 +18,7 @@ module Restyler.Monad.Docker
 
 import Restyler.Prelude
 
+import Data.List (nub)
 import Data.Text qualified as T
 import Restyler.AnnotatedException
 import System.Process.Typed
@@ -62,8 +63,13 @@ instance
   dockerCp src dst = runDocker_ ["cp", "--quiet", src, dst]
   dockerCpTar ps dst = do
     let
+      -- Ensure ps doesn't contain duplicates, otherwise you'll get an obscure
+      -- error from docker-cp, that it can't find /data.
+      --
+      -- https://github.com/restyled-io/actions/issues/391
+      --
       tArgs :: [String]
-      tArgs = ["-cf", "-"] <> map toFilePath ps
+      tArgs = ["-cf", "-"] <> map toFilePath (nub ps)
 
       dArgs :: [String]
       dArgs = ["cp", "--quiet", "-", dst]


### PR DESCRIPTION
If the list contains duplicates, you get an obscure error from `docker-cp`, that it can't find `/data`. Unclear why, but easy to avoid.

Fixes https://github.com/restyled-io/actions/issues/391